### PR TITLE
Allow up to 10 imports/dependencies

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -345,7 +345,7 @@ export const baseConfig = {
         'import/prefer-default-export': 'off',
         'import/newline-after-import': 'error',
         'import/no-nodejs-modules': 'off',
-        'import/max-dependencies': ['error', { max: 8 }],
+        'import/max-dependencies': ['error', { max: 10 }],
         'import/first': 'error',
         'import/no-unused-modules': 'error',
         'import/no-anonymous-default-export': 'off',


### PR DESCRIPTION
```ts
import type a from './a.js';
```

Should not be count as a dependency in my opinion. Often I need a lot of types in one module, especially when working with dependency injection, but not as many "real" runtime imports. Therefore there should be no limit in allowing type-only imports.