### PR TITLE
Override correct rule in test rules

### DIFF
--- a/configs/rule-sets/test-rules.js
+++ b/configs/rule-sets/test-rules.js
@@ -2,7 +2,7 @@ import { stylisticRuleSet } from './stylistic.js';
 
 export const testRuleSet = {
     rules: {
-        'max-len': [
+        '@stylistic/max-len': [
             'error',
             {
                 ...stylisticRuleSet.rules['@stylistic/max-len'][1],


### PR DESCRIPTION
Otherwise ESLint will still complain about too long test descriptions.