### PR TITLE
Enforce the use of the arrow function syntax for method signatures

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -218,7 +218,7 @@ export const typescriptConfig = {
         '@typescript-eslint/explicit-member-accessibility': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/init-declarations': 'off',
-        '@typescript-eslint/method-signature-style': ['error', 'method'],
+        '@typescript-eslint/method-signature-style': ['error', 'property'],
         '@typescript-eslint/no-base-to-string': 'error',
         ...configureWrappedCoreRule('no-dupe-class-members'),
         '@typescript-eslint/no-dynamic-delete': ['error'],


### PR DESCRIPTION
Because method shorthand syntax is considered harmful. Why is method shorthand syntax bad? You can read more about it including examples here: https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful