### PR TITLE
Enable Renovate auto-merge for all updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
     "labels": ["renovate", "upgrade"],
     "dependencyDashboard": false,
     "rebaseStalePrs": true,
+    "automerge": true,
+    "automergeType": "pr",
     "lockFileMaintenance": {
         "enabled": true,
         "automerge": true
@@ -12,12 +14,6 @@
         {
             "matchPackageNames": ["eslint", "@eslint/js", "eslint-plugin-ava"],
             "groupName": "ESLint packages"
-        },
-        {
-            "matchDepTypes": ["dependencies", "devDependencies"],
-            "matchUpdateTypes": ["minor", "patch"],
-            "automerge": true,
-            "automergeType": "pr"
         }
     ]
 }


### PR DESCRIPTION
Promote automerge to the top level so every update type (including majors) merges once required CI checks pass.