### PR TITLE
Enable packtory noDuplicatedFiles check

### DIFF
--- a/configs/ava.js
+++ b/configs/ava.js
@@ -1,5 +1,5 @@
 import avaPlugin from 'eslint-plugin-ava';
-import { testRuleSet } from './rule-sets/test-rules.js';
+import { testRuleSet } from './test-base.js';
 
 export const avaConfig = {
     plugins: {

--- a/configs/mocha.js
+++ b/configs/mocha.js
@@ -1,5 +1,5 @@
 import mochaPlugin from 'eslint-plugin-mocha';
-import { testRuleSet } from './rule-sets/test-rules.js';
+import { testRuleSet } from './test-base.js';
 
 export const mochaConfig = {
     plugins: {

--- a/configs/test-base.js
+++ b/configs/test-base.js
@@ -1,4 +1,4 @@
-import { stylisticRuleSet } from './stylistic.js';
+import { stylisticRuleSet } from './rule-sets/stylistic.js';
 
 export const testRuleSet = {
     rules: {

--- a/configs/vitest.js
+++ b/configs/vitest.js
@@ -1,5 +1,5 @@
 import vitestPlugin from '@vitest/eslint-plugin';
-import { testRuleSet } from './rule-sets/test-rules.js';
+import { testRuleSet } from './test-base.js';
 
 export const vitestConfig = {
     plugins: {

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -19,6 +19,12 @@ export async function buildConfig() {
 
     return {
         registrySettings: { token: npmToken },
+        checks: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [path.join(projectFolder, 'LICENSE')]
+            }
+        },
         commonPackageSettings: {
             sourcesFolder,
             mainPackageJson: packageJson,
@@ -87,9 +93,24 @@ export async function buildConfig() {
                 }
             },
             {
+                name: '@enormora/eslint-config-test-base',
+                entryPoints: [{ js: 'test-base.js' }],
+                bundlePeerDependencies: ['@enormora/eslint-config-base'],
+                additionalFiles: [
+                    {
+                        sourceFilePath: path.join(projectFolder, 'test-base.md'),
+                        targetFilePath: 'readme.md'
+                    }
+                ],
+                additionalPackageJsonAttributes: {
+                    description: 'Enormora’s shared ESLint rules for test files'
+                }
+            },
+            {
                 name: '@enormora/eslint-config-ava',
                 entryPoints: [{ js: 'ava.js' }],
                 bundlePeerDependencies: ['@enormora/eslint-config-base'],
+                bundleDependencies: ['@enormora/eslint-config-test-base'],
                 additionalFiles: [
                     {
                         sourceFilePath: path.join(projectFolder, 'ava.md'),
@@ -104,6 +125,7 @@ export async function buildConfig() {
                 name: '@enormora/eslint-config-mocha',
                 entryPoints: [{ js: 'mocha.js' }],
                 bundlePeerDependencies: ['@enormora/eslint-config-base'],
+                bundleDependencies: ['@enormora/eslint-config-test-base'],
                 additionalFiles: [
                     {
                         sourceFilePath: path.join(projectFolder, 'mocha.md'),
@@ -190,6 +212,7 @@ export async function buildConfig() {
                 name: '@enormora/eslint-config-vitest',
                 entryPoints: [{ js: 'vitest.js' }],
                 bundlePeerDependencies: ['@enormora/eslint-config-base'],
+                bundleDependencies: ['@enormora/eslint-config-test-base'],
                 additionalFiles: [
                     {
                         sourceFilePath: path.join(projectFolder, 'vitest.md'),

--- a/test-base.md
+++ b/test-base.md
@@ -1,0 +1,5 @@
+# `@enormora/eslint-config-test-base`
+
+Shared rule set used by the test-framework presets (`@enormora/eslint-config-ava`, `@enormora/eslint-config-mocha`, `@enormora/eslint-config-vitest`). It tweaks a few rules from the base preset to be more lenient inside test files.
+
+This package is consumed transitively through one of the test-framework presets and is not intended to be used directly.

--- a/test/rules-configuration.js
+++ b/test/rules-configuration.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import eslintCorePresets from '@eslint/js';
 import { Linter } from 'eslint';
 import ts from 'typescript';
-import { testRuleSet } from '../configs/rule-sets/test-rules.js';
+import { testRuleSet } from '../configs/test-base.js';
 
 function extractShortName(pluginName) {
     const prefix = 'eslint-plugin-';


### PR DESCRIPTION
Extracts shared test rules into a new @enormora/eslint-config-test-base package consumed by ava/mocha/vitest via bundleDependencies, and allow-lists LICENSE which is intentionally shipped with every package.