### PR TITLE
Add no-in-operator restricted-syntax rule

### DIFF
--- a/configs/presets/base/base-shared.js
+++ b/configs/presets/base/base-shared.js
@@ -8,6 +8,7 @@ import {
     createRestrictedSyntaxPlugin,
     noClassDeclarationRestriction,
     noEmptyFunctionBodyRestriction,
+    noInOperatorRestriction,
     noSwitchStatementRestriction
 } from '../../rule-sets/restricted-syntax.js';
 import { stylisticRuleSet } from '../../rule-sets/stylistic.js';
@@ -15,7 +16,8 @@ import { stylisticRuleSet } from '../../rule-sets/stylistic.js';
 const restrictedSyntaxPlugin = createRestrictedSyntaxPlugin([
     'no-class-declaration',
     'no-switch-statement',
-    'no-empty-function-body'
+    'no-empty-function-body',
+    'no-in-operator'
 ]);
 
 export const baseSharedConfig = {
@@ -128,6 +130,7 @@ export const baseSharedConfig = {
         'restricted-syntax/no-class-declaration': [ 'error', noClassDeclarationRestriction ],
         'restricted-syntax/no-switch-statement': [ 'error', noSwitchStatementRestriction ],
         'restricted-syntax/no-empty-function-body': [ 'error', noEmptyFunctionBodyRestriction ],
+        'restricted-syntax/no-in-operator': [ 'error', noInOperatorRestriction ],
         'no-return-assign': [ 'error', 'always' ],
         'no-self-assign': [ 'error', { props: true } ],
         'no-self-compare': 'error',

--- a/configs/rule-sets/restricted-syntax.js
+++ b/configs/rule-sets/restricted-syntax.js
@@ -42,3 +42,8 @@ export const noEmptyFunctionBodyRestriction = {
     selector: emptyFunctionBodySelector,
     message: 'Empty function bodies are not allowed, even with a comment.'
 };
+
+export const noInOperatorRestriction = {
+    selector: 'BinaryExpression[operator="in"]',
+    message: 'The `in` operator is not allowed. Use `Object.hasOwn` instead.'
+};

--- a/test/restricted-syntax.test.js
+++ b/test/restricted-syntax.test.js
@@ -6,6 +6,7 @@ import {
     createNoClassDeclarationRestriction,
     noClassDeclarationRestriction,
     noEmptyFunctionBodyRestriction,
+    noInOperatorRestriction,
     noSwitchStatementRestriction
 } from '../configs/rule-sets/restricted-syntax.js';
 import {
@@ -108,6 +109,21 @@ test('noEmptyFunctionBodyRestriction forbids empty bodies even with comments', (
             'const arrow = () => {};',
             'const arrow = () => { /* noop */ };',
             'const expr = function () {};'
+        ]
+    });
+});
+
+test('noInOperatorRestriction forbids the in operator but permits for-in loops', (t) => {
+    runRuleCases(t, javascriptRuleTester, noInOperatorRestriction, {
+        valid: [
+            'if (Object.hasOwn(bar, "foo")) {}',
+            'for (const key in bar) {}',
+            'const x = a < b;'
+        ],
+        invalid: [
+            'if ("foo" in bar) {}',
+            'const has = "foo" in bar;',
+            'function check(obj) { return "key" in obj; }'
         ]
     });
 });


### PR DESCRIPTION
Disallows the `in` operator in expressions (e.g. `'foo' in bar`) in favor of `Object.hasOwn`. `for…in` loops are unaffected since they parse as `ForInStatement`, not `BinaryExpression`.