### PR TITLE
Document workflow-security permissions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,8 +50,8 @@ jobs:
         runs-on: ubuntu-24.04
         name: Workflow security analysis
         permissions:
-            contents: read
-            security-events: write
+            contents: read # required for actions/checkout to read the workflow source
+            security-events: write # required by zizmor-action to upload SARIF to code scanning
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:


### PR DESCRIPTION
zizmor's undocumented-permissions audit (pedantic, added in v1.13) flags permission entries without an explanatory comment. Annotate the workflow-security job's permissions so the audit passes once a future zizmor release lands via renovate.