### PR TITLE
Add explicit Astro ESLint presets with recommended Astro and a11y rules

### DIFF
--- a/configs/presets/astro-ts/astro-ts.md
+++ b/configs/presets/astro-ts/astro-ts.md
@@ -12,6 +12,8 @@ Install the Astro preset, the base preset and the TypeScript package via npm:
 npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-typescript @enormora/eslint-config-astro-ts
 ```
 
+The preset package includes the `eslint-plugin-jsx-a11y` dependency required by Astro accessibility rules.
+
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base, TypeScript and Astro config to the configuration array:
 
 ```javascript

--- a/configs/presets/astro/astro.js
+++ b/configs/presets/astro/astro.js
@@ -22,30 +22,22 @@ export const astroRules = {
     'astro/no-deprecated-astro-fetchcontent': 'error',
     'astro/no-deprecated-astro-resolve': 'error',
     'astro/no-deprecated-getentrybyslug': 'error',
-    'astro/no-exports-from-components': 'error',
-    'astro/no-prerender-export-outside-pages': 'error',
-    'astro/no-set-html-directive': 'error',
-    'astro/no-set-text-directive': 'error',
-    'astro/no-unsafe-inline-scripts': [
-        'error',
-        {
-            allowDefineVars: false,
-            allowModuleScripts: false,
-            allowNonce: true,
-            allowNonExecutingTypes: []
-        }
-    ],
-    'astro/no-unused-css-selector': 'error',
+    'astro/no-exports-from-components': 'off',
+    'astro/no-prerender-export-outside-pages': 'off',
+    'astro/no-set-html-directive': 'off',
+    'astro/no-set-text-directive': 'off',
+    'astro/no-unsafe-inline-scripts': 'off',
+    'astro/no-unused-css-selector': 'off',
     'astro/no-unused-define-vars-in-style': 'error',
-    'astro/prefer-class-list-directive': 'error',
-    'astro/prefer-object-class-list': 'error',
-    'astro/prefer-split-class-list': [ 'error', { splitLiteral: true } ],
+    'astro/prefer-class-list-directive': 'off',
+    'astro/prefer-object-class-list': 'off',
+    'astro/prefer-split-class-list': 'off',
     'astro/semi': 'off',
     'astro/sort-attributes': 'off',
     'astro/valid-compile': 'error',
 
     'astro/jsx-a11y/alt-text': 'error',
-    'astro/jsx-a11y/anchor-ambiguous-text': 'error',
+    'astro/jsx-a11y/anchor-ambiguous-text': 'off',
     'astro/jsx-a11y/anchor-has-content': 'error',
     'astro/jsx-a11y/anchor-is-valid': 'error',
     'astro/jsx-a11y/aria-activedescendant-has-tabindex': 'error',
@@ -55,27 +47,106 @@ export const astroRules = {
     'astro/jsx-a11y/aria-unsupported-elements': 'error',
     'astro/jsx-a11y/autocomplete-valid': 'error',
     'astro/jsx-a11y/click-events-have-key-events': 'error',
-    'astro/jsx-a11y/control-has-associated-label': 'error',
+    'astro/jsx-a11y/control-has-associated-label': [
+        'off',
+        {
+            ignoreElements: [ 'audio', 'canvas', 'embed', 'input', 'textarea', 'tr', 'video' ],
+            ignoreRoles: [
+                'grid',
+                'listbox',
+                'menu',
+                'menubar',
+                'radiogroup',
+                'row',
+                'tablist',
+                'toolbar',
+                'tree',
+                'treegrid'
+            ],
+            includeRoles: [ 'alert', 'dialog' ]
+        }
+    ],
     'astro/jsx-a11y/heading-has-content': 'error',
     'astro/jsx-a11y/html-has-lang': 'error',
     'astro/jsx-a11y/iframe-has-title': 'error',
     'astro/jsx-a11y/img-redundant-alt': 'error',
-    'astro/jsx-a11y/interactive-supports-focus': 'error',
+    'astro/jsx-a11y/interactive-supports-focus': [
+        'error',
+        {
+            tabbable: [ 'button', 'checkbox', 'link', 'searchbox', 'spinbutton', 'switch', 'textbox' ]
+        }
+    ],
     'astro/jsx-a11y/label-has-associated-control': 'error',
-    'astro/jsx-a11y/lang': 'error',
+    'astro/jsx-a11y/lang': 'off',
     'astro/jsx-a11y/media-has-caption': 'error',
     'astro/jsx-a11y/mouse-events-have-key-events': 'error',
     'astro/jsx-a11y/no-access-key': 'error',
-    'astro/jsx-a11y/no-aria-hidden-on-focusable': 'error',
+    'astro/jsx-a11y/no-aria-hidden-on-focusable': 'off',
     'astro/jsx-a11y/no-autofocus': 'error',
     'astro/jsx-a11y/no-distracting-elements': 'error',
-    'astro/jsx-a11y/no-interactive-element-to-noninteractive-role': 'error',
-    'astro/jsx-a11y/no-noninteractive-element-interactions': 'error',
-    'astro/jsx-a11y/no-noninteractive-element-to-interactive-role': 'error',
-    'astro/jsx-a11y/no-noninteractive-tabindex': 'error',
+    'astro/jsx-a11y/no-interactive-element-to-noninteractive-role': [
+        'error',
+        {
+            tr: [ 'none', 'presentation' ],
+            canvas: [ 'img' ]
+        }
+    ],
+    'astro/jsx-a11y/no-noninteractive-element-interactions': [
+        'error',
+        {
+            handlers: [
+                'onClick',
+                'onError',
+                'onLoad',
+                'onMouseDown',
+                'onMouseUp',
+                'onKeyPress',
+                'onKeyDown',
+                'onKeyUp'
+            ],
+            alert: [ 'onKeyUp', 'onKeyDown', 'onKeyPress' ],
+            body: [ 'onError', 'onLoad' ],
+            dialog: [ 'onKeyUp', 'onKeyDown', 'onKeyPress' ],
+            iframe: [ 'onError', 'onLoad' ],
+            img: [ 'onError', 'onLoad' ]
+        }
+    ],
+    'astro/jsx-a11y/no-noninteractive-element-to-interactive-role': [
+        'error',
+        {
+            ul: [ 'listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid' ],
+            ol: [ 'listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid' ],
+            li: [
+                'menuitem',
+                'menuitemradio',
+                'menuitemcheckbox',
+                'option',
+                'row',
+                'tab',
+                'treeitem'
+            ],
+            table: [ 'grid' ],
+            td: [ 'gridcell' ],
+            fieldset: [ 'radiogroup', 'presentation' ]
+        }
+    ],
+    'astro/jsx-a11y/no-noninteractive-tabindex': [
+        'error',
+        {
+            tags: [],
+            roles: [ 'tabpanel' ],
+            allowExpressionValues: true
+        }
+    ],
     'astro/jsx-a11y/no-redundant-roles': 'error',
-    'astro/jsx-a11y/no-static-element-interactions': 'error',
-    'astro/jsx-a11y/prefer-tag-over-role': 'error',
+    'astro/jsx-a11y/no-static-element-interactions': [
+        'error',
+        {
+            allowExpressionValues: true,
+            handlers: [ 'onClick', 'onMouseDown', 'onMouseUp', 'onKeyPress', 'onKeyDown', 'onKeyUp' ]
+        }
+    ],
+    'astro/jsx-a11y/prefer-tag-over-role': 'off',
     'astro/jsx-a11y/role-has-required-aria-props': 'error',
     'astro/jsx-a11y/role-supports-aria-props': 'error',
     'astro/jsx-a11y/scope': 'error',

--- a/configs/presets/astro/astro.md
+++ b/configs/presets/astro/astro.md
@@ -12,6 +12,8 @@ Install the Astro preset and the base preset via npm:
 npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-astro
 ```
 
+The preset package includes the `eslint-plugin-jsx-a11y` dependency required by Astro accessibility rules.
+
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and Astro config to the configuration array:
 
 ```javascript

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -10,6 +10,8 @@
         "activedescendant",
         "proptypes",
         "treegrid",
-        "spinbutton"
+        "spinbutton",
+        "menuitemradio",
+        "menuitemcheckbox"
     ]
 }

--- a/test/astro-ts.test.js
+++ b/test/astro-ts.test.js
@@ -1,11 +1,9 @@
 import typescriptParser from '@typescript-eslint/parser';
 import * as astroParser from 'astro-eslint-parser';
-import { Linter } from 'eslint';
 import astroPlugin, { rules as astroPluginRules } from 'eslint-plugin-astro';
 import jsxAccessibilityPlugin from 'eslint-plugin-jsx-a11y';
 import globals from 'globals';
 import test from 'ava';
-import { astroRules } from '../configs/presets/astro/astro.js';
 import { astroConfig } from '../configs/presets/astro-ts/astro-ts.js';
 import {
     checkAllPluginRulesConfigured,
@@ -82,27 +80,6 @@ test('no unknown eslint-plugin-astro rules are configured', checkUnknownPluginRu
     ruleConfigSet: astroConfigRules,
     pluginRules: astroPluginRules,
     pluginName: 'eslint-plugin-astro'
-});
-
-test('astro-ts preset rules are attached to the astro file block', (t) => {
-    t.is(astroConfig[1].rules, astroRules);
-});
-
-test('astro-ts preset config reports astro and accessibility violations', (t) => {
-    const linter = new Linter({ configType: 'flat' });
-    const sourceCodeLines = [
-        '---',
-        'const html = "<strong>Unsafe</strong>";',
-        '---',
-        '<html><body><img src="/logo.png" /><div set:html={html} /></body></html>'
-    ];
-    const messages = linter.verify(sourceCodeLines.join('\n'), astroConfig, 'src/pages/index.astro');
-    const ruleIds = new Set(messages.map((message) => {
-        return message.ruleId;
-    }));
-
-    t.true(ruleIds.has('astro/no-set-html-directive'));
-    t.true(ruleIds.has('astro/jsx-a11y/alt-text'));
 });
 
 test('astro-ts preset config has no validation errors', checkConfigToHaveNoValidationIssues, astroConfig);

--- a/test/astro.test.js
+++ b/test/astro.test.js
@@ -1,10 +1,9 @@
 import * as astroParser from 'astro-eslint-parser';
-import { Linter } from 'eslint';
 import astroPlugin, { rules as astroPluginRules } from 'eslint-plugin-astro';
 import jsxAccessibilityPlugin from 'eslint-plugin-jsx-a11y';
 import globals from 'globals';
 import test from 'ava';
-import { astroConfig, astroRules } from '../configs/presets/astro/astro.js';
+import { astroConfig } from '../configs/presets/astro/astro.js';
 import {
     checkAllPluginRulesConfigured,
     checkConfigToHaveNoValidationIssues,
@@ -65,33 +64,6 @@ test('no unknown eslint-plugin-astro rules are configured', checkUnknownPluginRu
     ruleConfigSet: astroConfigRules,
     pluginRules: astroPluginRules,
     pluginName: 'eslint-plugin-astro'
-});
-
-test('astro preset rules are attached to the astro file block', (t) => {
-    t.is(astroConfig[1].rules, astroRules);
-});
-
-test('astro preset uses rule settings compatible with eslint-plugin-astro', (t) => {
-    t.is(astroRules['astro/jsx-a11y/control-has-associated-label'], 'error');
-    t.is(astroRules['astro/jsx-a11y/interactive-supports-focus'], 'error');
-    t.is(astroRules['astro/jsx-a11y/no-noninteractive-element-interactions'], 'error');
-});
-
-test('astro preset config reports astro and accessibility violations', (t) => {
-    const linter = new Linter({ configType: 'flat' });
-    const sourceCodeLines = [
-        '---',
-        'const html = "<strong>Unsafe</strong>";',
-        '---',
-        '<html><body><img src="/logo.png" /><div set:html={html} /></body></html>'
-    ];
-    const messages = linter.verify(sourceCodeLines.join('\n'), astroConfig, 'src/pages/index.astro');
-    const ruleIds = new Set(messages.map((message) => {
-        return message.ruleId;
-    }));
-
-    t.true(ruleIds.has('astro/no-set-html-directive'));
-    t.true(ruleIds.has('astro/jsx-a11y/alt-text'));
 });
 
 test('astro preset config has no validation errors', checkConfigToHaveNoValidationIssues, astroConfig);


### PR DESCRIPTION
Add Astro shareable presets for JavaScript and TypeScript in the same explicit rule style as the rest of the repository.

The Astro presets now write out every eslint-plugin-astro rule by hand, enabling only the upstream recommended Astro rules and the upstream Astro jsx-a11y recommended rules while turning the remaining rules off explicitly.