### PR TITLE
Migrate tests from AVA to Mocha

### DIFF
--- a/ava.config.js
+++ b/ava.config.js
@@ -1,3 +1,0 @@
-export default {
-    files: [ 'test/**/*.test.js' ]
-};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
-import { avaConfig } from './configs/presets/ava/ava.js';
+import cspellPlugin from '@cspell/eslint-plugin';
 import { baseConfig } from './configs/presets/base/base.js';
+import { mochaConfig } from './configs/presets/mocha/mocha.js';
 import { nodeConfig } from './configs/presets/node/node.js';
 
 const codeSpellCheckerRules = {
@@ -41,23 +42,33 @@ export default [
     nodeConfig,
     {
         files: [ 'configs/**/*.js' ],
+        plugins: {
+            '@cspell': cspellPlugin
+        },
         rules: {
             'max-lines': [ 'error', { max: 2000, skipBlankLines: true, skipComments: false } ],
             ...codeSpellCheckerRules
         }
     },
     {
-        files: [ 'eslint.config.js', 'prettier.config.js', 'ava.config.js' ],
+        files: [ 'eslint.config.js', 'prettier.config.js', 'mocha.config.json' ],
+        plugins: {
+            '@cspell': cspellPlugin
+        },
         rules: {
             'import/no-default-export': 'off',
             ...codeSpellCheckerRules
         }
     },
     {
-        ...avaConfig,
+        ...mochaConfig,
         files: [ 'test/**/*.test.js', 'test/rules-configuration.js' ],
+        plugins: {
+            ...mochaConfig.plugins,
+            '@cspell': cspellPlugin
+        },
         rules: {
-            ...avaConfig.rules,
+            ...mochaConfig.rules,
             ...codeSpellCheckerRules
         }
     }

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ lint: eslint
 lint-fix: eslint-fix
 
 test:
-    ava
+    mocha --config mocha.config.json
 
 packtory-dry-run:
     packtory publish

--- a/mocha.config.json
+++ b/mocha.config.json
@@ -1,0 +1,13 @@
+{
+    "diff": true,
+    "forbid-pending": true,
+    "extension": ["js"],
+    "spec": ["./test/**/*.test.js"],
+    "exclude": [],
+    "jobs": 1,
+    "parallel": false,
+    "reporter": "dot",
+    "slow": 75,
+    "timeout": 2000,
+    "ui": "tdd"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,8 +49,8 @@
             "devDependencies": {
                 "@eslint/js": "10.0.1",
                 "@packtory/cli": "0.0.15",
-                "ava": "8.0.1",
                 "eslint": "10.4.0",
+                "mocha": "11.7.5",
                 "prettier": "3.8.3",
                 "rust-just": "1.51.0",
                 "typescript": "6.0.3"
@@ -920,16 +920,6 @@
                 "node": ">=22.18.0"
             }
         },
-        "node_modules/@cto.af/wtf8": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/@cto.af/wtf8/-/wtf8-0.0.5.tgz",
-            "integrity": "sha512-LfUFi+Vv4eDzj+XAtR89e3wwjXA/NZjUSwU5NhwbBrLecxPaBYFy3exCuc1j+D4UZeOVdqlsl8G7LmOt18V0tg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            }
-        },
         "node_modules/@cyclonedx/cyclonedx-library": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-10.0.0.tgz",
@@ -1295,17 +1285,58 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
-        "node_modules/@isaacs/fs-minipass": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "minipass": "^7.0.4"
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -1351,28 +1382,6 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
-            "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "consola": "^3.2.3",
-                "detect-libc": "^2.0.0",
-                "https-proxy-agent": "^7.0.5",
-                "node-fetch": "^2.6.7",
-                "nopt": "^8.0.0",
-                "semver": "^7.5.3",
-                "tar": "^7.4.0"
-            },
-            "bin": {
-                "node-pre-gyp": "bin/node-pre-gyp"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
@@ -1652,6 +1661,17 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@pkgr/core": {
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -1707,29 +1727,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/@rollup/pluginutils": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-            "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "estree-walker": "^2.0.2",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@schema-hub/zod-error-formatter": {
@@ -2332,9 +2329,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2347,9 +2341,6 @@
             "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2364,9 +2355,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2379,9 +2367,6 @@
             "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2396,9 +2381,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2411,9 +2393,6 @@
             "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2428,9 +2407,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2443,9 +2419,6 @@
             "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2508,33 +2481,6 @@
                 "win32"
             ]
         },
-        "node_modules/@vercel/nft": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.5.0.tgz",
-            "integrity": "sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@mapbox/node-pre-gyp": "^2.0.0",
-                "@rollup/pluginutils": "^5.1.3",
-                "acorn": "^8.6.0",
-                "acorn-import-attributes": "^1.9.5",
-                "async-sema": "^3.1.1",
-                "bindings": "^1.4.0",
-                "estree-walker": "2.0.2",
-                "glob": "^13.0.0",
-                "graceful-fs": "^4.2.9",
-                "node-gyp-build": "^4.2.2",
-                "picomatch": "^4.0.2",
-                "resolve-from": "^5.0.0"
-            },
-            "bin": {
-                "nft": "out/cli.js"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
         "node_modules/@vitest/eslint-plugin": {
             "version": "1.6.17",
             "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.17.tgz",
@@ -2565,16 +2511,6 @@
                 }
             }
         },
-        "node_modules/abbrev": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
-            "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^18.17.0 || >=20.5.0"
-            }
-        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2587,16 +2523,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/acorn-import-attributes": {
-            "version": "1.9.5",
-            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "acorn": "^8"
-            }
-        },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -2604,19 +2530,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/acorn-walk": {
-            "version": "8.3.5",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-            "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.11.0"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/agent-base": {
@@ -2737,16 +2650,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
         "node_modules/aria-query": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -2770,16 +2673,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/array-find-index": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/array-includes": {
@@ -2903,29 +2796,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/arrgv": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/arrgv/-/arrgv-1.0.2.tgz",
-            "integrity": "sha512-a4eg4yhp7mmruZDQFqVMlxNRFGi/i1r87pt8SDHy0/I8PqSXoUTlWZRdAZo0VXgvEARcujbtTk8kiZRi1uDGRw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/arrify": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
-            "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/ast-types-flow": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2985,13 +2855,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/async-sema": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
-            "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3008,69 +2871,6 @@
             "dependencies": {
                 "stubborn-fs": "^2.0.0",
                 "when-exit": "^2.1.4"
-            }
-        },
-        "node_modules/ava": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/ava/-/ava-8.0.1.tgz",
-            "integrity": "sha512-YlwwL5HX2EJRE75e2LR8nio8lKAJ702sFbv0QYnhzngAjyo9wB+Xg4JZh5f432khlWfVD5OQ93rrRopEXJptpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vercel/nft": "^1.5.0",
-                "acorn": "^8.16.0",
-                "acorn-walk": "^8.3.5",
-                "ansi-styles": "^6.2.3",
-                "arrgv": "^1.0.2",
-                "arrify": "^3.0.0",
-                "callsites": "^4.2.0",
-                "cbor2": "^2.3.0",
-                "chalk": "^5.6.2",
-                "chunkd": "^2.0.1",
-                "ci-info": "^4.4.0",
-                "ci-parallel-vars": "^1.0.1",
-                "cli-truncate": "^6.0.0",
-                "code-excerpt": "^4.0.0",
-                "common-path-prefix": "^3.0.0",
-                "concordance": "^5.0.4",
-                "currently-unhandled": "^0.4.1",
-                "debug": "^4.4.3",
-                "emittery": "^2.0.0",
-                "figures": "^6.1.0",
-                "globby": "^16.2.0",
-                "ignore-by-default": "^2.1.0",
-                "indent-string": "^5.0.0",
-                "is-plain-object": "^5.0.0",
-                "is-promise": "^4.0.0",
-                "matcher": "^6.0.0",
-                "memoize": "^11.0.0",
-                "ms": "^2.1.3",
-                "p-map": "^7.0.4",
-                "package-config": "^5.0.0",
-                "picomatch": "^4.0.4",
-                "plur": "^6.0.0",
-                "pretty-ms": "^9.3.0",
-                "resolve-cwd": "^3.0.0",
-                "slash": "^5.1.0",
-                "stack-utils": "^2.0.6",
-                "supertap": "^3.0.1",
-                "temp-dir": "^3.0.0",
-                "write-file-atomic": "^7.0.1",
-                "yargs": "^18.0.0"
-            },
-            "bin": {
-                "ava": "entrypoints/cli.js"
-            },
-            "engines": {
-                "node": "^22.20 || ^24.12 || >=26"
-            },
-            "peerDependencies": {
-                "@ava/typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "@ava/typescript": {
-                    "optional": true
-                }
             }
         },
         "node_modules/available-typed-arrays": {
@@ -3257,23 +3057,6 @@
                 "node": ">=18.18.0"
             }
         },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
-        "node_modules/blueimp-md5": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
-            "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3364,6 +3147,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/browserslist": {
             "version": "4.28.2",
@@ -3498,19 +3288,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/callsites": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-4.2.0.tgz",
-            "integrity": "sha512-kfzR4zzQtAE9PC7CzZsjl3aBNbXWuXiSeOCdLcPpBfGW8YuCqQHcRPFDbr/BPVmd3EEPVpuFzLyuT/cUhPr4OQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/camelcase": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -3544,19 +3321,6 @@
             ],
             "license": "CC-BY-4.0"
         },
-        "node_modules/cbor2": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/cbor2/-/cbor2-2.3.0.tgz",
-            "integrity": "sha512-76WB3hq8BoaGkMkBVJ27fW5LJU+qqDLEpgRNCG/SYKhODWXpVPOTD4UcUto3IEzYLA52nsvbhb0wabhHDn3qXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@cto.af/wtf8": "0.0.5"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
         "node_modules/chalk": {
             "version": "5.6.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -3589,22 +3353,21 @@
             "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
             "license": "MIT"
         },
-        "node_modules/chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+        "node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
             "engines": {
-                "node": ">=18"
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
-        },
-        "node_modules/chunkd": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/chunkd/-/chunkd-2.0.1.tgz",
-            "integrity": "sha512-7d58XsFmOq0j6el67Ug9mHf9ELUXsQXYJBkyxhH/k+6Ke0qXRnv0kbemx+Twc6fRJ07C49lcbdgm9FL1Ei/6SQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/ci-info": {
             "version": "4.4.0",
@@ -3620,13 +3383,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/ci-parallel-vars": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.1.tgz",
-            "integrity": "sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/clean-regexp": {
             "version": "1.0.0",
@@ -3657,23 +3413,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-truncate": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.0.0.tgz",
-            "integrity": "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "slice-ansi": "^9.0.0",
-                "string-width": "^8.2.0"
-            },
-            "engines": {
-                "node": ">=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -3738,19 +3477,6 @@
             "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/code-excerpt": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
-            "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "convert-to-spaces": "^2.0.1"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -3821,13 +3547,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/common-path-prefix": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-            "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/common-tags": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -3843,26 +3562,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
-        },
-        "node_modules/concordance": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.4.tgz",
-            "integrity": "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "date-time": "^3.1.0",
-                "esutils": "^2.0.3",
-                "fast-diff": "^1.2.0",
-                "js-string-escape": "^1.0.1",
-                "lodash": "^4.17.15",
-                "md5-hex": "^3.0.1",
-                "semver": "^7.3.2",
-                "well-known-symbols": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.18.0 <11 || >=12.14.0 <13 || >=14"
-            }
         },
         "node_modules/config-chain": {
             "version": "1.1.13",
@@ -3901,31 +3600,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/consola": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-            "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.18.0 || >=16.10.0"
-            }
-        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "license": "MIT"
-        },
-        "node_modules/convert-to-spaces": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
-            "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
         },
         "node_modules/core-js-compat": {
             "version": "3.49.0",
@@ -4086,19 +3765,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/currently-unhandled": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-find-index": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4156,19 +3822,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/date-time": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
-            "integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "time-zone": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4184,6 +3837,19 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/deep-extend": {
@@ -4254,16 +3920,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/didyoumean": {
@@ -4343,24 +3999,18 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.357",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
             "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
             "license": "ISC"
-        },
-        "node_modules/emittery": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/emittery/-/emittery-2.0.0.tgz",
-            "integrity": "sha512-FLtgn/CGBXiX3ZtPAm5q4LWWepHChOt55J9u01WFu3dyap2U7IwptlrqoE1COR/kxwdy/DOxIBALSxIW449I1g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=22"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-            }
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -5543,13 +5193,6 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5722,13 +5365,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -5783,6 +5419,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "bin": {
+                "flat": "cli.js"
+            }
+        },
         "node_modules/flat-cache": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -5817,6 +5463,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/form-data": {
@@ -6100,27 +5763,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/globby": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-            "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/merge-streams": "^4.0.0",
-                "fast-glob": "^3.3.3",
-                "ignore": "^7.0.5",
-                "is-path-inside": "^4.0.0",
-                "slash": "^5.1.0",
-                "unicorn-magic": "^0.4.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/globrex": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
@@ -6171,6 +5813,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/has-property-descriptors": {
@@ -6237,6 +5889,16 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "he": "bin/he"
             }
         },
         "node_modules/hermes-estree": {
@@ -6349,16 +6011,6 @@
                 "node": ">= 4"
             }
         },
-        "node_modules/ignore-by-default": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-2.1.0.tgz",
-            "integrity": "sha512-yiWd4GVmJp0Q6ghmM2B/V3oZGRmjrKLXvHR3TE1nfoXsmoggllfZUQe74EN0fJdPFZu2NIvNdrMMLm3OsV7Ohw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10 <11 || >=12 <13 || >=14"
-            }
-        },
         "node_modules/import-fresh": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-4.0.0.tgz",
@@ -6447,19 +6099,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
-            }
-        },
-        "node_modules/irregular-plurals": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-4.2.0.tgz",
-            "integrity": "sha512-bW9UXHL7bnUcNtTo+9ccSngbxc+V40H32IgvdVin0Xs8gbo+AVYD5g/72ce/54Kjfhq66vcZr8H8TKEvsifeOw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-array-buffer": {
@@ -6659,22 +6298,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-east-asian-width": "^1.3.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-generator-function": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -6867,23 +6490,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-promise": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/is-regex": {
             "version": "1.2.1",
@@ -7089,14 +6695,20 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/js-string-escape": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-            "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
             }
         },
         "node_modules/js-tokens": {
@@ -7104,20 +6716,6 @@
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "license": "MIT"
-        },
-        "node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
@@ -7353,19 +6951,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/load-json-file": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-7.0.1.tgz",
-            "integrity": "sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7399,6 +6984,82 @@
             "resolved": "https://registry.npmjs.org/lodash.zipobject/-/lodash.zipobject-4.18.0.tgz",
             "integrity": "sha512-crXabtkOHmlyg/VoiR0wzEjbl8b+owY2Z8wBhoyoGPya/9YkUsxpCe7UJkL+ZtQFBBQXnk08kz9W0iieQNeu9w==",
             "license": "MIT"
+        },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-symbols/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/log-symbols/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/log-symbols/node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-symbols/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
@@ -7445,35 +7106,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/matcher": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/matcher/-/matcher-6.0.0.tgz",
-            "integrity": "sha512-TzDerdcNtI79w7Av4GT57bLdElPA/VAkjqdMZv8yhuc8geU2z0ljW9anXbX/55aHEMTpYypZb1lxsA/46r9oOQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "escape-string-regexp": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/matcher/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7481,35 +7113,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/md5-hex": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
-            "integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "blueimp-md5": "^2.10.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/memoize": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/memoize/-/memoize-11.0.0.tgz",
-            "integrity": "sha512-cjsfZaC9b1clqPeIVMbb5dLHSXgdgGWGxdAU3oTUUkHiwWTKTBNnSmcqWJncNjYtBi3S8Rp0c5GIiyGztR8TRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-function": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=22"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/memoize?sponsor=1"
             }
         },
         "node_modules/merge2": {
@@ -7573,19 +7176,6 @@
             },
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/mimic-function": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/minimatch": {
@@ -7746,6 +7336,308 @@
                 "node": ">= 18"
             }
         },
+        "node_modules/mocha": {
+            "version": "11.7.5",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+            "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browser-stdout": "^1.3.1",
+                "chokidar": "^4.0.1",
+                "debug": "^4.3.5",
+                "diff": "^7.0.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-up": "^5.0.0",
+                "glob": "^10.4.5",
+                "he": "^1.2.0",
+                "is-path-inside": "^3.0.3",
+                "js-yaml": "^4.1.0",
+                "log-symbols": "^4.1.0",
+                "minimatch": "^9.0.5",
+                "ms": "^2.1.3",
+                "picocolors": "^1.1.1",
+                "serialize-javascript": "^6.0.2",
+                "strip-json-comments": "^3.1.1",
+                "supports-color": "^8.1.1",
+                "workerpool": "^9.2.0",
+                "yargs": "^17.7.2",
+                "yargs-parser": "^21.1.1",
+                "yargs-unparser": "^2.0.0"
+            },
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha.js"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/mocha/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mocha/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/mocha/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/mocha/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/mocha/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/mocha/node_modules/diff": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/mocha/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/mocha/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/mocha/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mocha/node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mocha/node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/mocha/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/mocha/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/mocha/node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/mocha/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mocha/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mocha/node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mocha/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/mocha/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/mocha/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7837,60 +7729,11 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/node-gyp-build": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "node-gyp-build": "bin.js",
-                "node-gyp-build-optional": "optional.js",
-                "node-gyp-build-test": "build-test.js"
-            }
-        },
         "node_modules/node-releases": {
             "version": "2.0.44",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
             "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
             "license": "MIT"
-        },
-        "node_modules/nopt": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-            "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "^3.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^18.17.0 || >=20.5.0"
-            }
         },
         "node_modules/normalize-exception": {
             "version": "4.0.1",
@@ -8360,23 +8203,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/package-config": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/package-config/-/package-config-5.0.0.tgz",
-            "integrity": "sha512-GYTTew2slBcYdvRHqjhwaaydVMvn/qrGC323+nKclYioNSLTDUM/lGgtGTgyHVtYcozb+XkE8CNhwcraOmZ9Mg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "find-up-simple": "^1.0.0",
-                "load-json-file": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/package-json": {
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
@@ -8395,6 +8221,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
         },
         "node_modules/packtory": {
             "version": "0.0.15",
@@ -8549,22 +8382,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/plur": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/plur/-/plur-6.0.0.tgz",
-            "integrity": "sha512-Y9wXQivjRX0REtwpA9+n0bYYypWESn3cWtW2vazymw711qn+AQXxzZjRqhANYGBLIMC1UzVdpwe/1hHQwHfwng==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "irregular-plurals": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/pluralize": {
@@ -8753,6 +8570,16 @@
             ],
             "license": "MIT"
         },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
         "node_modules/rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -8857,6 +8684,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/refa": {
@@ -9017,19 +8858,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/resolve-cwd": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "resolve-from": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/resolve-from": {
@@ -9272,6 +9100,27 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/safe-push-apply": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9339,33 +9188,14 @@
                 "node": ">=10"
             }
         },
-        "node_modules/serialize-error": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+        "node_modules/serialize-javascript": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
-            "license": "MIT",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "type-fest": "^0.13.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/serialize-error/node_modules/type-fest": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "randombytes": "^2.1.0"
             }
         },
         "node_modules/set-function-length": {
@@ -9540,36 +9370,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/slash": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/slice-ansi": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
-            "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.3",
-                "is-fullwidth-code-point": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=22"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
-        },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -9679,13 +9479,6 @@
             "dev": true,
             "license": "CC0-1.0"
         },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
         "node_modules/ssri": {
             "version": "13.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
@@ -9706,29 +9499,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "node_modules/stack-utils": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "escape-string-regexp": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/stack-utils/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/stop-iteration-iterator": {
@@ -9756,21 +9526,60 @@
                 "text-decoder": "^1.1.0"
             }
         },
-        "node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "get-east-asian-width": "^1.5.0",
-                "strip-ansi": "^7.1.2"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/string.prototype.includes": {
@@ -9896,6 +9705,30 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-final-newline": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -9948,20 +9781,20 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/supertap": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/supertap/-/supertap-3.0.1.tgz",
-            "integrity": "sha512-u1ZpIBCawJnO+0QePsEiOknOfCRq0yERxiAchT0i4li0WHNUJbf0evXXSXOcCAR4M8iMDoajXYmstm/qO81Isw==",
+        "node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "indent-string": "^5.0.0",
-                "js-yaml": "^3.14.1",
-                "serialize-error": "^7.0.1",
-                "strip-ansi": "^7.0.1"
+                "has-flag": "^4.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/supports-preserve-symlinks-flag": {
@@ -10017,23 +9850,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/tar": {
-            "version": "7.5.15",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-            "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/tar-stream": {
             "version": "3.1.8",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
@@ -10047,16 +9863,6 @@
                 "streamx": "^2.15.0"
             }
         },
-        "node_modules/tar/node_modules/yallist": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/teex": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
@@ -10067,16 +9873,6 @@
                 "streamx": "^2.12.5"
             }
         },
-        "node_modules/temp-dir": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
-            "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            }
-        },
         "node_modules/text-decoder": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
@@ -10085,16 +9881,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.6.4"
-            }
-        },
-        "node_modules/time-zone": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-            "integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/tinyglobby": {
@@ -10124,13 +9910,6 @@
             "engines": {
                 "node": ">=8.0"
             }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/true-myth": {
             "version": "9.3.1",
@@ -10360,19 +10139,6 @@
             "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/unicorn-magic": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
-            "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/unix-permissions": {
             "version": "6.0.1",
@@ -10700,34 +10466,6 @@
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
             }
         },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true,
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/well-known-symbols": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
-            "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "node_modules/when-exit": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
@@ -10887,6 +10625,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/workerpool": {
+            "version": "9.3.4",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+            "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/wrap-ansi": {
             "version": "9.0.2",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -10903,6 +10648,96 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrap-ansi/node_modules/emoji-regex": {
@@ -10928,19 +10763,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/write-file-atomic": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
-            "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/xdg-basedir": {
@@ -11021,6 +10843,45 @@
             "license": "ISC",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/yargs-unparser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-unparser/node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yargs-unparser/node_modules/is-plain-obj": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/yargs/node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "devDependencies": {
         "@eslint/js": "10.0.1",
         "@packtory/cli": "0.0.15",
-        "ava": "8.0.1",
         "eslint": "10.4.0",
+        "mocha": "11.7.5",
         "prettier": "3.8.3",
         "rust-just": "1.51.0",
         "typescript": "6.0.3"

--- a/test/astro-ts.test.js
+++ b/test/astro-ts.test.js
@@ -1,9 +1,10 @@
+import assert from 'node:assert';
 import typescriptParser from '@typescript-eslint/parser';
 import * as astroParser from 'astro-eslint-parser';
 import astroPlugin, { rules as astroPluginRules } from 'eslint-plugin-astro';
 import jsxAccessibilityPlugin from 'eslint-plugin-jsx-a11y';
 import globals from 'globals';
-import test from 'ava';
+import { suite, test } from 'mocha';
 import { astroConfig } from '../configs/presets/astro-ts/astro-ts.js';
 import {
     checkAllPluginRulesConfigured,
@@ -14,72 +15,80 @@ import {
 
 const astroConfigRules = mergeConfigRules(astroConfig);
 
-test('astro-ts preset config has the correct plugin defined', (t) => {
-    t.deepEqual(astroConfig[0], {
-        plugins: {
-            astro: astroPlugin,
-            'jsx-a11y': jsxAccessibilityPlugin
-        }
+suite('astro-ts preset', function () {
+    test('astro-ts preset config has the correct plugin defined', function () {
+        assert.deepStrictEqual(astroConfig[0], {
+            plugins: {
+                astro: astroPlugin,
+                'jsx-a11y': jsxAccessibilityPlugin
+            }
+        });
     });
-});
 
-test('astro-ts preset config has the correct astro language options defined', (t) => {
-    t.deepEqual(astroConfig[1].languageOptions, {
-        parser: astroParser,
-        globals: {
-            ...globals.node,
-            ...globals.es2025,
-            Astro: false,
-            Fragment: false
-        },
-        parserOptions: {
+    test('astro-ts preset config has the correct astro language options defined', function () {
+        assert.deepStrictEqual(astroConfig[1].languageOptions, {
+            parser: astroParser,
+            globals: {
+                ...globals.node,
+                ...globals.es2025,
+                Astro: false,
+                Fragment: false
+            },
+            parserOptions: {
+                parser: typescriptParser,
+                extraFileExtensions: [ '.astro' ],
+                warnOnUnsupportedTypeScriptVersion: false,
+                sourceType: 'module'
+            }
+        });
+    });
+
+    test('astro-ts preset config has the correct processor set', function () {
+        assert.strictEqual(astroConfig[1].processor, 'astro/client-side-ts');
+    });
+
+    test('astro-ts preset config has the correct client script language options defined', function () {
+        assert.deepStrictEqual(astroConfig[2].languageOptions, {
+            globals: {
+                ...globals.browser,
+                ...globals.es2025
+            },
+            parserOptions: {
+                sourceType: 'module'
+            }
+        });
+
+        assert.deepStrictEqual(astroConfig[3].languageOptions, {
             parser: typescriptParser,
-            extraFileExtensions: [ '.astro' ],
-            warnOnUnsupportedTypeScriptVersion: false,
-            sourceType: 'module'
-        }
-    });
-});
-
-test('astro-ts preset config has the correct processor set', (t) => {
-    t.is(astroConfig[1].processor, 'astro/client-side-ts');
-});
-
-test('astro-ts preset config has the correct client script language options defined', (t) => {
-    t.deepEqual(astroConfig[2].languageOptions, {
-        globals: {
-            ...globals.browser,
-            ...globals.es2025
-        },
-        parserOptions: {
-            sourceType: 'module'
-        }
+            globals: {
+                ...globals.browser,
+                ...globals.es2025
+            },
+            parserOptions: {
+                warnOnUnsupportedTypeScriptVersion: false,
+                sourceType: 'module',
+                project: null
+            }
+        });
     });
 
-    t.deepEqual(astroConfig[3].languageOptions, {
-        parser: typescriptParser,
-        globals: {
-            ...globals.browser,
-            ...globals.es2025
-        },
-        parserOptions: {
-            warnOnUnsupportedTypeScriptVersion: false,
-            sourceType: 'module',
-            project: null
-        }
+    test('all eslint-plugin-astro rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: astroConfigRules,
+            pluginRules: astroPluginRules,
+            pluginName: 'eslint-plugin-astro'
+        });
+    });
+
+    test('no unknown eslint-plugin-astro rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: astroConfigRules,
+            pluginRules: astroPluginRules,
+            pluginName: 'eslint-plugin-astro'
+        });
+    });
+
+    test('astro-ts preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(astroConfig);
     });
 });
-
-test('all eslint-plugin-astro rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: astroConfigRules,
-    pluginRules: astroPluginRules,
-    pluginName: 'eslint-plugin-astro'
-});
-
-test('no unknown eslint-plugin-astro rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: astroConfigRules,
-    pluginRules: astroPluginRules,
-    pluginName: 'eslint-plugin-astro'
-});
-
-test('astro-ts preset config has no validation errors', checkConfigToHaveNoValidationIssues, astroConfig);

--- a/test/astro.test.js
+++ b/test/astro.test.js
@@ -1,8 +1,9 @@
+import assert from 'node:assert';
 import * as astroParser from 'astro-eslint-parser';
 import astroPlugin, { rules as astroPluginRules } from 'eslint-plugin-astro';
 import jsxAccessibilityPlugin from 'eslint-plugin-jsx-a11y';
 import globals from 'globals';
-import test from 'ava';
+import { suite, test } from 'mocha';
 import { astroConfig } from '../configs/presets/astro/astro.js';
 import {
     checkAllPluginRulesConfigured,
@@ -13,57 +14,65 @@ import {
 
 const astroConfigRules = mergeConfigRules(astroConfig);
 
-test('astro preset config has the correct plugin defined', (t) => {
-    t.deepEqual(astroConfig[0], {
-        plugins: {
-            astro: astroPlugin,
-            'jsx-a11y': jsxAccessibilityPlugin
-        }
+suite('astro preset', function () {
+    test('astro preset config has the correct plugin defined', function () {
+        assert.deepStrictEqual(astroConfig[0], {
+            plugins: {
+                astro: astroPlugin,
+                'jsx-a11y': jsxAccessibilityPlugin
+            }
+        });
+    });
+
+    test('astro preset config has the correct astro language options defined', function () {
+        assert.deepStrictEqual(astroConfig[1].languageOptions, {
+            parser: astroParser,
+            globals: {
+                ...globals.node,
+                ...globals.es2025,
+                Astro: false,
+                Fragment: false
+            },
+            parserOptions: {
+                extraFileExtensions: [ '.astro' ],
+                sourceType: 'module'
+            }
+        });
+    });
+
+    test('astro preset config has the correct processor set', function () {
+        assert.strictEqual(astroConfig[1].processor, 'astro/astro');
+    });
+
+    test('astro preset config has the correct client script language options defined', function () {
+        assert.deepStrictEqual(astroConfig[2].languageOptions, {
+            globals: {
+                ...globals.browser,
+                ...globals.es2025
+            },
+            parserOptions: {
+                sourceType: 'module'
+            }
+        });
+    });
+
+    test('all eslint-plugin-astro rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: astroConfigRules,
+            pluginRules: astroPluginRules,
+            pluginName: 'eslint-plugin-astro'
+        });
+    });
+
+    test('no unknown eslint-plugin-astro rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: astroConfigRules,
+            pluginRules: astroPluginRules,
+            pluginName: 'eslint-plugin-astro'
+        });
+    });
+
+    test('astro preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(astroConfig);
     });
 });
-
-test('astro preset config has the correct astro language options defined', (t) => {
-    t.deepEqual(astroConfig[1].languageOptions, {
-        parser: astroParser,
-        globals: {
-            ...globals.node,
-            ...globals.es2025,
-            Astro: false,
-            Fragment: false
-        },
-        parserOptions: {
-            extraFileExtensions: [ '.astro' ],
-            sourceType: 'module'
-        }
-    });
-});
-
-test('astro preset config has the correct processor set', (t) => {
-    t.is(astroConfig[1].processor, 'astro/astro');
-});
-
-test('astro preset config has the correct client script language options defined', (t) => {
-    t.deepEqual(astroConfig[2].languageOptions, {
-        globals: {
-            ...globals.browser,
-            ...globals.es2025
-        },
-        parserOptions: {
-            sourceType: 'module'
-        }
-    });
-});
-
-test('all eslint-plugin-astro rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: astroConfigRules,
-    pluginRules: astroPluginRules,
-    pluginName: 'eslint-plugin-astro'
-});
-
-test('no unknown eslint-plugin-astro rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: astroConfigRules,
-    pluginRules: astroPluginRules,
-    pluginName: 'eslint-plugin-astro'
-});
-
-test('astro preset config has no validation errors', checkConfigToHaveNoValidationIssues, astroConfig);

--- a/test/ava.test.js
+++ b/test/ava.test.js
@@ -1,4 +1,4 @@
-import test from 'ava';
+import { suite, test } from 'mocha';
 import avaPlugin from 'eslint-plugin-ava';
 import { avaConfig } from '../configs/presets/ava/ava.js';
 import {
@@ -8,20 +8,30 @@ import {
     checkUnknownPluginRulesAreNotConfigured
 } from './rules-configuration.js';
 
-test('all eslint-plugin-ava rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: avaConfig.rules,
-    pluginRules: avaPlugin.rules,
-    pluginName: 'eslint-plugin-ava'
-});
+suite('ava preset', function () {
+    test('all eslint-plugin-ava rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: avaConfig.rules,
+            pluginRules: avaPlugin.rules,
+            pluginName: 'eslint-plugin-ava'
+        });
+    });
 
-test('no unknown eslint-plugin-ava rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: avaConfig.rules,
-    pluginRules: avaPlugin.rules,
-    pluginName: 'eslint-plugin-ava'
-});
+    test('no unknown eslint-plugin-ava rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: avaConfig.rules,
+            pluginRules: avaPlugin.rules,
+            pluginName: 'eslint-plugin-ava'
+        });
+    });
 
-test('all common test rules are configured', checkAllTestRulesConfigured, {
-    ruleConfigSet: avaConfig.rules
-});
+    test('all common test rules are configured', function () {
+        checkAllTestRulesConfigured({
+            ruleConfigSet: avaConfig.rules
+        });
+    });
 
-test('ava preset config has no validation errors', checkConfigToHaveNoValidationIssues, avaConfig);
+    test('ava preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(avaConfig);
+    });
+});

--- a/test/aws-cdk.test.js
+++ b/test/aws-cdk.test.js
@@ -1,5 +1,9 @@
-import test from 'ava';
+import { suite, test } from 'mocha';
 import { awsCdkConfig } from '../configs/presets/aws-cdk/aws-cdk.js';
 import { checkConfigToHaveNoValidationIssues } from './rules-configuration.js';
 
-test('aws-cdk preset config has no validation errors', checkConfigToHaveNoValidationIssues, awsCdkConfig);
+suite('aws-cdk preset', function () {
+    test('aws-cdk preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(awsCdkConfig);
+    });
+});

--- a/test/base-best-practices.test.js
+++ b/test/base-best-practices.test.js
@@ -1,4 +1,4 @@
-import test from 'ava';
+import { suite, test } from 'mocha';
 import arrayFunctionPlugin from 'eslint-plugin-array-func';
 import noBarrelFiles from 'eslint-plugin-no-barrel-files';
 import promisePlugin from 'eslint-plugin-promise';
@@ -13,62 +13,84 @@ import {
 
 const baseConfigRules = mergeConfigRules(baseConfig);
 
-test('all eslint-plugin-unicorn rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: unicornPlugin.rules,
-    pluginName: 'eslint-plugin-unicorn'
-});
+suite('base best practices rule set', function () {
+    test('all eslint-plugin-unicorn rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: unicornPlugin.rules,
+            pluginName: 'eslint-plugin-unicorn'
+        });
+    });
 
-test('no unknown eslint-plugin-unicorn rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: unicornPlugin.rules,
-    pluginName: 'eslint-plugin-unicorn'
-});
+    test('no unknown eslint-plugin-unicorn rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: unicornPlugin.rules,
+            pluginName: 'eslint-plugin-unicorn'
+        });
+    });
 
-test('all eslint-plugin-promise rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: promisePlugin.rules,
-    pluginName: 'eslint-plugin-promise'
-});
+    test('all eslint-plugin-promise rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: promisePlugin.rules,
+            pluginName: 'eslint-plugin-promise'
+        });
+    });
 
-test('no unknown eslint-plugin-promise rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: promisePlugin.rules,
-    pluginName: 'eslint-plugin-promise'
-});
+    test('no unknown eslint-plugin-promise rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: promisePlugin.rules,
+            pluginName: 'eslint-plugin-promise'
+        });
+    });
 
-test('all eslint-plugin-array-func rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: arrayFunctionPlugin.rules,
-    pluginName: 'eslint-plugin-array-func'
-});
+    test('all eslint-plugin-array-func rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: arrayFunctionPlugin.rules,
+            pluginName: 'eslint-plugin-array-func'
+        });
+    });
 
-test('no unknown eslint-plugin-array-func rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: arrayFunctionPlugin.rules,
-    pluginName: 'eslint-plugin-array-func'
-});
+    test('no unknown eslint-plugin-array-func rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: arrayFunctionPlugin.rules,
+            pluginName: 'eslint-plugin-array-func'
+        });
+    });
 
-test('all eslint-plugin-sonarjs rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: sonarjsPlugin.rules,
-    pluginName: 'eslint-plugin-sonarjs'
-});
+    test('all eslint-plugin-sonarjs rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: sonarjsPlugin.rules,
+            pluginName: 'eslint-plugin-sonarjs'
+        });
+    });
 
-test('no unknown eslint-plugin-sonarjs rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: sonarjsPlugin.rules,
-    pluginName: 'eslint-plugin-sonarjs'
-});
+    test('no unknown eslint-plugin-sonarjs rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: sonarjsPlugin.rules,
+            pluginName: 'eslint-plugin-sonarjs'
+        });
+    });
 
-test('all eslint-plugin-no-barrel-files rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: noBarrelFiles.rules,
-    pluginName: 'eslint-plugin-no-barrel-files'
-});
+    test('all eslint-plugin-no-barrel-files rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: noBarrelFiles.rules,
+            pluginName: 'eslint-plugin-no-barrel-files'
+        });
+    });
 
-test('no unknown eslint-plugin-no-barrel-files rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: noBarrelFiles.rules,
-    pluginName: 'eslint-plugin-no-barrel-files'
+    test('no unknown eslint-plugin-no-barrel-files rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: noBarrelFiles.rules,
+            pluginName: 'eslint-plugin-no-barrel-files'
+        });
+    });
 });

--- a/test/base-stylistic-rules.test.js
+++ b/test/base-stylistic-rules.test.js
@@ -1,6 +1,6 @@
 import dprintPlugin from '@ben_12/eslint-plugin-dprint';
 import stylisticPlugin from '@stylistic/eslint-plugin';
-import test from 'ava';
+import { suite, test } from 'mocha';
 import destructuringPlugin from 'eslint-plugin-destructuring';
 import { baseConfig } from '../configs/presets/base/base.js';
 import {
@@ -11,38 +11,52 @@ import {
 
 const baseConfigRules = mergeConfigRules(baseConfig);
 
-test('all @ben_12/eslint-plugin-dprint rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: dprintPlugin.rules,
-    pluginName: '@ben_12/eslint-plugin-dprint'
-});
+suite('base stylistic rules', function () {
+    test('all @ben_12/eslint-plugin-dprint rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: dprintPlugin.rules,
+            pluginName: '@ben_12/eslint-plugin-dprint'
+        });
+    });
 
-test('no unknown @ben_12/eslint-plugin-dprint rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: dprintPlugin.rules,
-    pluginName: '@ben_12/eslint-plugin-dprint'
-});
+    test('no unknown @ben_12/eslint-plugin-dprint rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: dprintPlugin.rules,
+            pluginName: '@ben_12/eslint-plugin-dprint'
+        });
+    });
 
-test('all eslint-plugin-destructuring rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: destructuringPlugin.rules,
-    pluginName: 'eslint-plugin-destructuring'
-});
+    test('all eslint-plugin-destructuring rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: destructuringPlugin.rules,
+            pluginName: 'eslint-plugin-destructuring'
+        });
+    });
 
-test('no unknown eslint-plugin-destructuring rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: destructuringPlugin.rules,
-    pluginName: 'eslint-plugin-destructuring'
-});
+    test('no unknown eslint-plugin-destructuring rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: destructuringPlugin.rules,
+            pluginName: 'eslint-plugin-destructuring'
+        });
+    });
 
-test('all @stylistic/eslint-plugin rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: stylisticPlugin.rules,
-    pluginName: '@stylistic'
-});
+    test('all @stylistic/eslint-plugin rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: stylisticPlugin.rules,
+            pluginName: '@stylistic'
+        });
+    });
 
-test('no unknown @stylistic/eslint-plugin rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: stylisticPlugin.rules,
-    pluginName: '@stylistic'
+    test('no unknown @stylistic/eslint-plugin rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: stylisticPlugin.rules,
+            pluginName: '@stylistic'
+        });
+    });
 });

--- a/test/base-with-prettier.test.js
+++ b/test/base-with-prettier.test.js
@@ -1,5 +1,5 @@
 import eslintCommentsPlugin from '@eslint-community/eslint-plugin-eslint-comments';
-import test from 'ava';
+import { suite, test } from 'mocha';
 import { rules as importPluginRules } from 'eslint-plugin-import-x';
 import noSecretsPlugin from 'eslint-plugin-no-secrets';
 import prettierPlugin from 'eslint-plugin-prettier';
@@ -12,68 +12,88 @@ import {
     checkUnknownPluginRulesAreNotConfigured
 } from './rules-configuration.js';
 
-test('all core rules are configured', checkAllCoreRulesConfigured, {
-    ruleConfigSet: baseWithPrettierConfig.rules
+suite('base-with-prettier preset', function () {
+    suite('base rules', function () {
+        test('all core rules are configured', function () {
+            checkAllCoreRulesConfigured({
+                ruleConfigSet: baseWithPrettierConfig.rules
+            });
+        });
+
+        test('does not contain removed core rules', function () {
+            checkUnknownCoreRulesAreNotConfigured({
+                ruleConfigSet: baseWithPrettierConfig.rules
+            });
+        });
+
+        test('all eslint-plugin-no-secrets rules are configured', function () {
+            checkAllPluginRulesConfigured({
+                ruleConfigSet: baseWithPrettierConfig.rules,
+                pluginRules: noSecretsPlugin.rules,
+                pluginName: 'eslint-plugin-no-secrets'
+            });
+        });
+
+        test('no unknown eslint-plugin-no-secrets rules are configured', function () {
+            checkUnknownPluginRulesAreNotConfigured({
+                ruleConfigSet: baseWithPrettierConfig.rules,
+                pluginRules: noSecretsPlugin.rules,
+                pluginName: 'eslint-plugin-no-secrets'
+            });
+        });
+
+        test('all eslint-plugin-import rules are configured', function () {
+            checkAllPluginRulesConfigured({
+                ruleConfigSet: baseWithPrettierConfig.rules,
+                pluginRules: importPluginRules,
+                pluginName: 'eslint-plugin-import'
+            });
+        });
+
+        test('no unknown eslint-plugin-import rules are configured', function () {
+            checkUnknownPluginRulesAreNotConfigured({
+                ruleConfigSet: baseWithPrettierConfig.rules,
+                pluginRules: importPluginRules,
+                pluginName: 'eslint-plugin-import'
+            });
+        });
+    });
+
+    suite('plugin coverage', function () {
+        test('all @eslint-community/eslint-plugin-eslint-comments rules are configured', function () {
+            checkAllPluginRulesConfigured({
+                ruleConfigSet: baseWithPrettierConfig.rules,
+                pluginRules: eslintCommentsPlugin.rules,
+                pluginName: 'eslint-plugin-eslint-comments'
+            });
+        });
+
+        test('no unknown @eslint-community/eslint-plugin-eslint-comments rules are configured', function () {
+            checkUnknownPluginRulesAreNotConfigured({
+                ruleConfigSet: baseWithPrettierConfig.rules,
+                pluginRules: eslintCommentsPlugin.rules,
+                pluginName: 'eslint-plugin-eslint-comments'
+            });
+        });
+
+        test('all eslint-plugin-prettier rules are configured', function () {
+            checkAllPluginRulesConfigured({
+                ruleConfigSet: baseWithPrettierConfig.rules,
+                pluginRules: prettierPlugin.rules,
+                pluginName: 'eslint-plugin-prettier'
+            });
+        });
+
+        test('no unknown eslint-plugin-prettier rules are configured', function () {
+            checkUnknownPluginRulesAreNotConfigured({
+                ruleConfigSet: baseWithPrettierConfig.rules,
+                pluginRules: prettierPlugin.rules,
+                pluginName: 'eslint-plugin-prettier'
+            });
+        });
+
+        test('base-with-prettier preset config has no validation errors', function () {
+            checkConfigToHaveNoValidationIssues(baseWithPrettierConfig);
+        });
+    });
 });
-
-test('does not contain removed core rules', checkUnknownCoreRulesAreNotConfigured, {
-    ruleConfigSet: baseWithPrettierConfig.rules
-});
-
-test('all eslint-plugin-no-secrets rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseWithPrettierConfig.rules,
-    pluginRules: noSecretsPlugin.rules,
-    pluginName: 'eslint-plugin-no-secrets'
-});
-
-test('no unknown eslint-plugin-no-secrets rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseWithPrettierConfig.rules,
-    pluginRules: noSecretsPlugin.rules,
-    pluginName: 'eslint-plugin-no-secrets'
-});
-
-test('all eslint-plugin-import rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseWithPrettierConfig.rules,
-    pluginRules: importPluginRules,
-    pluginName: 'eslint-plugin-import'
-});
-
-test('no unknown eslint-plugin-import rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseWithPrettierConfig.rules,
-    pluginRules: importPluginRules,
-    pluginName: 'eslint-plugin-import'
-});
-
-test('all @eslint-community/eslint-plugin-eslint-comments rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseWithPrettierConfig.rules,
-    pluginRules: eslintCommentsPlugin.rules,
-    pluginName: 'eslint-plugin-eslint-comments'
-});
-
-test(
-    'no unknown @eslint-community/eslint-plugin-eslint-comments rules are configured',
-    checkUnknownPluginRulesAreNotConfigured,
-    {
-        ruleConfigSet: baseWithPrettierConfig.rules,
-        pluginRules: eslintCommentsPlugin.rules,
-        pluginName: 'eslint-plugin-eslint-comments'
-    }
-);
-
-test('all eslint-plugin-prettier rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseWithPrettierConfig.rules,
-    pluginRules: prettierPlugin.rules,
-    pluginName: 'eslint-plugin-prettier'
-});
-
-test('no unknown eslint-plugin-prettier rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseWithPrettierConfig.rules,
-    pluginRules: prettierPlugin.rules,
-    pluginName: 'eslint-plugin-prettier'
-});
-
-test(
-    'base-with-prettier preset config has no validation errors',
-    checkConfigToHaveNoValidationIssues,
-    baseWithPrettierConfig
-);

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,5 +1,5 @@
 import eslintCommentsPlugin from '@eslint-community/eslint-plugin-eslint-comments';
-import test from 'ava';
+import { suite, test } from 'mocha';
 import { rules as importPluginRules } from 'eslint-plugin-import-x';
 import noSecretsPlugin from 'eslint-plugin-no-secrets';
 import { baseConfig } from '../configs/presets/base/base.js';
@@ -14,52 +14,68 @@ import {
 
 const baseConfigRules = mergeConfigRules(baseConfig);
 
-test('all core rules are configured', checkAllCoreRulesConfigured, {
-    ruleConfigSet: baseConfigRules
+suite('base preset', function () {
+    test('all core rules are configured', function () {
+        checkAllCoreRulesConfigured({
+            ruleConfigSet: baseConfigRules
+        });
+    });
+
+    test('does not contain removed core rules', function () {
+        checkUnknownCoreRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules
+        });
+    });
+
+    test('all eslint-plugin-no-secrets rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: noSecretsPlugin.rules,
+            pluginName: 'eslint-plugin-no-secrets'
+        });
+    });
+
+    test('no unknown eslint-plugin-no-secrets rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: noSecretsPlugin.rules,
+            pluginName: 'eslint-plugin-no-secrets'
+        });
+    });
+
+    test('all eslint-plugin-import rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: importPluginRules,
+            pluginName: 'eslint-plugin-import'
+        });
+    });
+
+    test('no unknown eslint-plugin-import rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: importPluginRules,
+            pluginName: 'eslint-plugin-import'
+        });
+    });
+
+    test('all @eslint-community/eslint-plugin-eslint-comments rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: eslintCommentsPlugin.rules,
+            pluginName: 'eslint-plugin-eslint-comments'
+        });
+    });
+
+    test('no unknown @eslint-community/eslint-plugin-eslint-comments rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: baseConfigRules,
+            pluginRules: eslintCommentsPlugin.rules,
+            pluginName: 'eslint-plugin-eslint-comments'
+        });
+    });
+
+    test('base preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(baseConfig);
+    });
 });
-
-test('does not contain removed core rules', checkUnknownCoreRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules
-});
-
-test('all eslint-plugin-no-secrets rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: noSecretsPlugin.rules,
-    pluginName: 'eslint-plugin-no-secrets'
-});
-
-test('no unknown eslint-plugin-no-secrets rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: noSecretsPlugin.rules,
-    pluginName: 'eslint-plugin-no-secrets'
-});
-
-test('all eslint-plugin-import rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: importPluginRules,
-    pluginName: 'eslint-plugin-import'
-});
-
-test('no unknown eslint-plugin-import rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: importPluginRules,
-    pluginName: 'eslint-plugin-import'
-});
-
-test('all @eslint-community/eslint-plugin-eslint-comments rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: baseConfigRules,
-    pluginRules: eslintCommentsPlugin.rules,
-    pluginName: 'eslint-plugin-eslint-comments'
-});
-
-test(
-    'no unknown @eslint-community/eslint-plugin-eslint-comments rules are configured',
-    checkUnknownPluginRulesAreNotConfigured,
-    {
-        ruleConfigSet: baseConfigRules,
-        pluginRules: eslintCommentsPlugin.rules,
-        pluginName: 'eslint-plugin-eslint-comments'
-    }
-);
-
-test('base preset config has no validation errors', checkConfigToHaveNoValidationIssues, baseConfig);

--- a/test/integration/base-node.test.js
+++ b/test/integration/base-node.test.js
@@ -1,4 +1,5 @@
-import test from 'ava';
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
 import { baseConfig } from '../../configs/presets/base/base.js';
 import { nodeConfig } from '../../configs/presets/node/node.js';
 import { fixFixture, lintFixture, resolveFixture, uniqueSortedRuleIds } from './lint-fixture.js';
@@ -71,23 +72,25 @@ const expectedViolationRuleIds = [
     'unicorn/prefer-string-slice'
 ];
 
-test('base+node violations fixture reports the expected rule ids', async (t) => {
-    const { messages } = await lintFixture(configs, comboName, 'violations.js');
-    t.deepEqual(uniqueSortedRuleIds(messages), expectedViolationRuleIds);
-});
-
-test('base+node clean fixture produces no reports', async (t) => {
-    const { messages } = await lintFixture(configs, comboName, 'clean.js');
-    const detail = messages.map((message) => {
-        return { ruleId: message.ruleId, line: message.line, message: message.message };
+suite('base+node integration', function () {
+    test('base+node violations fixture reports the expected rule ids', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'violations.js');
+        assert.deepStrictEqual(uniqueSortedRuleIds(messages), expectedViolationRuleIds);
     });
-    t.deepEqual(detail, []);
-});
 
-test('base+node autofix is idempotent on the violations fixture', async (t) => {
-    const { code, filePath } = await resolveFixture(comboName, 'violations.js');
-    const firstPass = fixFixture(configs, code, filePath);
-    const secondPass = fixFixture(configs, firstPass.output, filePath);
-    t.is(secondPass.output, firstPass.output, 'second autofix pass changed the output');
-    t.false(secondPass.fixed, 'second autofix pass reported further fixes');
+    test('base+node clean fixture produces no reports', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'clean.js');
+        const detail = messages.map((message) => {
+            return { ruleId: message.ruleId, line: message.line, message: message.message };
+        });
+        assert.deepStrictEqual(detail, []);
+    });
+
+    test('base+node autofix is idempotent on the violations fixture', async function () {
+        const { code, filePath } = await resolveFixture(comboName, 'violations.js');
+        const firstPass = fixFixture(configs, code, filePath);
+        const secondPass = fixFixture(configs, firstPass.output, filePath);
+        assert.strictEqual(secondPass.output, firstPass.output, 'second autofix pass changed the output');
+        assert.strictEqual(secondPass.fixed, false, 'second autofix pass reported further fixes');
+    });
 });

--- a/test/integration/base-typescript-node.test.js
+++ b/test/integration/base-typescript-node.test.js
@@ -1,4 +1,5 @@
-import test from 'ava';
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
 import { baseConfig } from '../../configs/presets/base/base.js';
 import { nodeConfig } from '../../configs/presets/node/node.js';
 import { typescriptConfig } from '../../configs/presets/typescript/typescript.js';
@@ -112,23 +113,25 @@ const expectedViolationRuleIds = [
     'unicorn/prefer-string-slice'
 ];
 
-test('base+typescript+node violations fixture reports the expected rule ids', async (t) => {
-    const { messages } = await lintFixture(configs, comboName, 'violations.ts');
-    t.deepEqual(uniqueSortedRuleIds(messages), expectedViolationRuleIds);
-});
-
-test('base+typescript+node clean fixture produces no reports', async (t) => {
-    const { messages } = await lintFixture(configs, comboName, 'clean.ts');
-    const detail = messages.map((message) => {
-        return { ruleId: message.ruleId, line: message.line, message: message.message };
+suite('base+typescript+node integration', function () {
+    test('base+typescript+node violations fixture reports the expected rule ids', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'violations.ts');
+        assert.deepStrictEqual(uniqueSortedRuleIds(messages), expectedViolationRuleIds);
     });
-    t.deepEqual(detail, []);
-});
 
-test('base+typescript+node autofix is idempotent on the violations fixture', async (t) => {
-    const { code, filePath } = await resolveFixture(comboName, 'violations.ts');
-    const firstPass = fixFixture(configs, code, filePath);
-    const secondPass = fixFixture(configs, firstPass.output, filePath);
-    t.is(secondPass.output, firstPass.output, 'second autofix pass changed the output');
-    t.false(secondPass.fixed, 'second autofix pass reported further fixes');
+    test('base+typescript+node clean fixture produces no reports', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'clean.ts');
+        const detail = messages.map((message) => {
+            return { ruleId: message.ruleId, line: message.line, message: message.message };
+        });
+        assert.deepStrictEqual(detail, []);
+    });
+
+    test('base+typescript+node autofix is idempotent on the violations fixture', async function () {
+        const { code, filePath } = await resolveFixture(comboName, 'violations.ts');
+        const firstPass = fixFixture(configs, code, filePath);
+        const secondPass = fixFixture(configs, firstPass.output, filePath);
+        assert.strictEqual(secondPass.output, firstPass.output, 'second autofix pass changed the output');
+        assert.strictEqual(secondPass.fixed, false, 'second autofix pass reported further fixes');
+    });
 });

--- a/test/integration/base-typescript-react-tsx.test.js
+++ b/test/integration/base-typescript-react-tsx.test.js
@@ -1,7 +1,8 @@
-import test from 'ava';
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
 import { baseConfig } from '../../configs/presets/base/base.js';
-import { typescriptConfig } from '../../configs/presets/typescript/typescript.js';
 import { reactTsxConfig } from '../../configs/presets/react-tsx/react-tsx.js';
+import { typescriptConfig } from '../../configs/presets/typescript/typescript.js';
 import { fixFixture, lintFixture, resolveFixture, uniqueSortedRuleIds } from './lint-fixture.js';
 
 const comboName = 'base-typescript-react-tsx';
@@ -39,23 +40,25 @@ const expectedViolationRuleIds = [
     'sonarjs/prefer-read-only-props'
 ];
 
-test('base+typescript+react-tsx violations fixture reports the expected rule ids', async (t) => {
-    const { messages } = await lintFixture(configs, comboName, 'violations.tsx');
-    t.deepEqual(uniqueSortedRuleIds(messages), expectedViolationRuleIds);
-});
-
-test('base+typescript+react-tsx clean fixture produces no reports', async (t) => {
-    const { messages } = await lintFixture(configs, comboName, 'clean.tsx');
-    const detail = messages.map((message) => {
-        return { ruleId: message.ruleId, line: message.line, message: message.message };
+suite('base+typescript+react-tsx integration', function () {
+    test('base+typescript+react-tsx violations fixture reports the expected rule ids', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'violations.tsx');
+        assert.deepStrictEqual(uniqueSortedRuleIds(messages), expectedViolationRuleIds);
     });
-    t.deepEqual(detail, []);
-});
 
-test('base+typescript+react-tsx autofix is idempotent on the violations fixture', async (t) => {
-    const { code, filePath } = await resolveFixture(comboName, 'violations.tsx');
-    const firstPass = fixFixture(configs, code, filePath);
-    const secondPass = fixFixture(configs, firstPass.output, filePath);
-    t.is(secondPass.output, firstPass.output, 'second autofix pass changed the output');
-    t.false(secondPass.fixed, 'second autofix pass reported further fixes');
+    test('base+typescript+react-tsx clean fixture produces no reports', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'clean.tsx');
+        const detail = messages.map((message) => {
+            return { ruleId: message.ruleId, line: message.line, message: message.message };
+        });
+        assert.deepStrictEqual(detail, []);
+    });
+
+    test('base+typescript+react-tsx autofix is idempotent on the violations fixture', async function () {
+        const { code, filePath } = await resolveFixture(comboName, 'violations.tsx');
+        const firstPass = fixFixture(configs, code, filePath);
+        const secondPass = fixFixture(configs, firstPass.output, filePath);
+        assert.strictEqual(secondPass.output, firstPass.output, 'second autofix pass changed the output');
+        assert.strictEqual(secondPass.fixed, false, 'second autofix pass reported further fixes');
+    });
 });

--- a/test/integration/base-typescript.test.js
+++ b/test/integration/base-typescript.test.js
@@ -1,4 +1,5 @@
-import test from 'ava';
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
 import { baseConfig } from '../../configs/presets/base/base.js';
 import { typescriptConfig } from '../../configs/presets/typescript/typescript.js';
 import { fixFixture, lintFixture, resolveFixture, uniqueSortedRuleIds } from './lint-fixture.js';
@@ -109,23 +110,25 @@ const expectedViolationRuleIds = [
     'unicorn/prefer-string-slice'
 ];
 
-test('base+typescript violations fixture reports the expected rule ids', async (t) => {
-    const { messages } = await lintFixture(configs, comboName, 'violations.ts');
-    t.deepEqual(uniqueSortedRuleIds(messages), expectedViolationRuleIds);
-});
-
-test('base+typescript clean fixture produces no reports', async (t) => {
-    const { messages } = await lintFixture(configs, comboName, 'clean.ts');
-    const detail = messages.map((message) => {
-        return { ruleId: message.ruleId, line: message.line, message: message.message };
+suite('base+typescript integration', function () {
+    test('base+typescript violations fixture reports the expected rule ids', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'violations.ts');
+        assert.deepStrictEqual(uniqueSortedRuleIds(messages), expectedViolationRuleIds);
     });
-    t.deepEqual(detail, []);
-});
 
-test('base+typescript autofix is idempotent on the violations fixture', async (t) => {
-    const { code, filePath } = await resolveFixture(comboName, 'violations.ts');
-    const firstPass = fixFixture(configs, code, filePath);
-    const secondPass = fixFixture(configs, firstPass.output, filePath);
-    t.is(secondPass.output, firstPass.output, 'second autofix pass changed the output');
-    t.false(secondPass.fixed, 'second autofix pass reported further fixes');
+    test('base+typescript clean fixture produces no reports', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'clean.ts');
+        const detail = messages.map((message) => {
+            return { ruleId: message.ruleId, line: message.line, message: message.message };
+        });
+        assert.deepStrictEqual(detail, []);
+    });
+
+    test('base+typescript autofix is idempotent on the violations fixture', async function () {
+        const { code, filePath } = await resolveFixture(comboName, 'violations.ts');
+        const firstPass = fixFixture(configs, code, filePath);
+        const secondPass = fixFixture(configs, firstPass.output, filePath);
+        assert.strictEqual(secondPass.output, firstPass.output, 'second autofix pass changed the output');
+        assert.strictEqual(secondPass.fixed, false, 'second autofix pass reported further fixes');
+    });
 });

--- a/test/mocha.test.js
+++ b/test/mocha.test.js
@@ -1,4 +1,4 @@
-import test from 'ava';
+import { suite, test } from 'mocha';
 import mochaPlugin from 'eslint-plugin-mocha';
 import { mochaConfig } from '../configs/presets/mocha/mocha.js';
 import {
@@ -10,31 +10,45 @@ import {
     checkUnknownPluginRulesAreNotConfigured
 } from './rules-configuration.js';
 
-test('all eslint-plugin-mocha rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: mochaConfig.rules,
-    pluginRules: mochaPlugin.rules,
-    pluginName: 'eslint-plugin-mocha'
-});
+suite('mocha preset', function () {
+    test('all eslint-plugin-mocha rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: mochaConfig.rules,
+            pluginRules: mochaPlugin.rules,
+            pluginName: 'eslint-plugin-mocha'
+        });
+    });
 
-test('no unknown eslint-plugin-mocha rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: mochaConfig.rules,
-    pluginRules: mochaPlugin.rules,
-    pluginName: 'eslint-plugin-mocha'
-});
+    test('no unknown eslint-plugin-mocha rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: mochaConfig.rules,
+            pluginRules: mochaPlugin.rules,
+            pluginName: 'eslint-plugin-mocha'
+        });
+    });
 
-test('all common test rules are configured', checkAllTestRulesConfigured, {
-    ruleConfigSet: mochaConfig.rules
-});
+    test('all common test rules are configured', function () {
+        checkAllTestRulesConfigured({
+            ruleConfigSet: mochaConfig.rules
+        });
+    });
 
-test('mocha preset config has no validation errors', checkConfigToHaveNoValidationIssues, mochaConfig);
+    test('mocha preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(mochaConfig);
+    });
 
-test('mocha preset config has the correct language options defined', checkConfigLanguageOptions, {
-    configLanguageOptions: mochaConfig.languageOptions
-});
+    test('mocha preset config has the correct language options defined', function () {
+        checkConfigLanguageOptions({
+            configLanguageOptions: mochaConfig.languageOptions
+        });
+    });
 
-test('mocha preset config defines additional rules', checkAdditionalRulesConfigured, {
-    ruleConfigSet: mochaConfig.rules,
-    additionalRules: {
-        'prefer-arrow-callback': 'off'
-    }
+    test('mocha preset config defines additional rules', function () {
+        checkAdditionalRulesConfigured({
+            ruleConfigSet: mochaConfig.rules,
+            additionalRules: {
+                'prefer-arrow-callback': 'off'
+            }
+        });
+    });
 });

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -1,4 +1,4 @@
-import test from 'ava';
+import { suite, test } from 'mocha';
 import nodePlugin from 'eslint-plugin-n';
 import { nodeConfig, nodeConfigFileConfig, nodeEntryPointFileConfig } from '../configs/presets/node/node.js';
 import {
@@ -7,28 +7,32 @@ import {
     checkUnknownPluginRulesAreNotConfigured
 } from './rules-configuration.js';
 
-test('all eslint-plugin-n rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: nodeConfig.rules,
-    pluginRules: nodePlugin.rules,
-    pluginName: 'eslint-plugin-node'
+suite('node preset', function () {
+    test('all eslint-plugin-n rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: nodeConfig.rules,
+            pluginRules: nodePlugin.rules,
+            pluginName: 'eslint-plugin-node'
+        });
+    });
+
+    test('no unknown eslint-plugin-n rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: nodeConfig.rules,
+            pluginRules: nodePlugin.rules,
+            pluginName: 'eslint-plugin-node'
+        });
+    });
+
+    test('node preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(nodeConfig);
+    });
+
+    test('node config file preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(nodeConfigFileConfig);
+    });
+
+    test('node entry point file preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(nodeEntryPointFileConfig);
+    });
 });
-
-test('no unknown eslint-plugin-n rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: nodeConfig.rules,
-    pluginRules: nodePlugin.rules,
-    pluginName: 'eslint-plugin-node'
-});
-
-test('node preset config has no validation errors', checkConfigToHaveNoValidationIssues, nodeConfig);
-
-test(
-    'node config file preset config has no validation errors',
-    checkConfigToHaveNoValidationIssues,
-    nodeConfigFileConfig
-);
-
-test(
-    'node entry point file preset config has no validation errors',
-    checkConfigToHaveNoValidationIssues,
-    nodeEntryPointFileConfig
-);

--- a/test/react-jsx.test.js
+++ b/test/react-jsx.test.js
@@ -1,4 +1,4 @@
-import test from 'ava';
+import { suite, test } from 'mocha';
 import reactPlugin from 'eslint-plugin-react';
 import hooksPlugin from 'eslint-plugin-react-hooks';
 import { reactJsxConfig } from '../configs/presets/react-jsx/react-jsx.js';
@@ -9,39 +9,53 @@ import {
     checkUnknownPluginRulesAreNotConfigured
 } from './rules-configuration.js';
 
-test('react preset config has the correct language options defined', checkConfigLanguageOptions, {
-    configLanguageOptions: reactJsxConfig.languageOptions,
-    languageOptions: {
-        parserOptions: {
-            ecmaFeatures: {
-                jsx: true
+suite('react-jsx preset', function () {
+    test('react preset config has the correct language options defined', function () {
+        checkConfigLanguageOptions({
+            configLanguageOptions: reactJsxConfig.languageOptions,
+            languageOptions: {
+                parserOptions: {
+                    ecmaFeatures: {
+                        jsx: true
+                    }
+                }
             }
-        }
-    }
-});
+        });
+    });
 
-test('all eslint-plugin-react rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: reactJsxConfig.rules,
-    pluginRules: reactPlugin.rules,
-    pluginName: 'eslint-plugin-react'
-});
+    test('all eslint-plugin-react rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: reactJsxConfig.rules,
+            pluginRules: reactPlugin.rules,
+            pluginName: 'eslint-plugin-react'
+        });
+    });
 
-test('no unknown eslint-plugin-react rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: reactJsxConfig.rules,
-    pluginRules: reactPlugin.rules,
-    pluginName: 'eslint-plugin-react'
-});
+    test('no unknown eslint-plugin-react rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: reactJsxConfig.rules,
+            pluginRules: reactPlugin.rules,
+            pluginName: 'eslint-plugin-react'
+        });
+    });
 
-test('all eslint-plugin-react-hooks rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: reactJsxConfig.rules,
-    pluginRules: hooksPlugin.rules,
-    pluginName: 'eslint-plugin-react-hooks'
-});
+    test('all eslint-plugin-react-hooks rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: reactJsxConfig.rules,
+            pluginRules: hooksPlugin.rules,
+            pluginName: 'eslint-plugin-react-hooks'
+        });
+    });
 
-test('no unknown eslint-plugin-react-hooks rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: reactJsxConfig.rules,
-    pluginRules: hooksPlugin.rules,
-    pluginName: 'eslint-plugin-react-hooks'
-});
+    test('no unknown eslint-plugin-react-hooks rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: reactJsxConfig.rules,
+            pluginRules: hooksPlugin.rules,
+            pluginName: 'eslint-plugin-react-hooks'
+        });
+    });
 
-test('react preset config has no validation errors', checkConfigToHaveNoValidationIssues, reactJsxConfig);
+    test('react preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(reactJsxConfig);
+    });
+});

--- a/test/react-tsx.test.js
+++ b/test/react-tsx.test.js
@@ -1,14 +1,18 @@
-import test from 'ava';
+import { suite, test } from 'mocha';
 import { reactTsxConfig } from '../configs/presets/react-tsx/react-tsx.js';
 import { checkConfigLanguageOptions } from './rules-configuration.js';
 
-test('react-tsx preset config has the correct language options defined', checkConfigLanguageOptions, {
-    configLanguageOptions: reactTsxConfig.languageOptions,
-    languageOptions: {
-        parserOptions: {
-            ecmaFeatures: {
-                jsx: true
+suite('react-tsx preset', function () {
+    test('react-tsx preset config has the correct language options defined', function () {
+        checkConfigLanguageOptions({
+            configLanguageOptions: reactTsxConfig.languageOptions,
+            languageOptions: {
+                parserOptions: {
+                    ecmaFeatures: {
+                        jsx: true
+                    }
+                }
             }
-        }
-    }
+        });
+    });
 });

--- a/test/react.test.js
+++ b/test/react.test.js
@@ -1,4 +1,4 @@
-import test from 'ava';
+import { suite, test } from 'mocha';
 import reactPlugin from 'eslint-plugin-react';
 import hooksPlugin from 'eslint-plugin-react-hooks';
 import { reactConfig } from '../configs/presets/react/react.js';
@@ -8,28 +8,40 @@ import {
     checkUnknownPluginRulesAreNotConfigured
 } from './rules-configuration.js';
 
-test('all eslint-plugin-react rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: reactConfig.rules,
-    pluginRules: reactPlugin.rules,
-    pluginName: 'eslint-plugin-react'
-});
+suite('react preset', function () {
+    test('all eslint-plugin-react rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: reactConfig.rules,
+            pluginRules: reactPlugin.rules,
+            pluginName: 'eslint-plugin-react'
+        });
+    });
 
-test('no unknown eslint-plugin-react rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: reactConfig.rules,
-    pluginRules: reactPlugin.rules,
-    pluginName: 'eslint-plugin-react'
-});
+    test('no unknown eslint-plugin-react rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: reactConfig.rules,
+            pluginRules: reactPlugin.rules,
+            pluginName: 'eslint-plugin-react'
+        });
+    });
 
-test('all eslint-plugin-react-hooks rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: reactConfig.rules,
-    pluginRules: hooksPlugin.rules,
-    pluginName: 'eslint-plugin-react-hooks'
-});
+    test('all eslint-plugin-react-hooks rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: reactConfig.rules,
+            pluginRules: hooksPlugin.rules,
+            pluginName: 'eslint-plugin-react-hooks'
+        });
+    });
 
-test('no unknown eslint-plugin-react-hooks rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: reactConfig.rules,
-    pluginRules: hooksPlugin.rules,
-    pluginName: 'eslint-plugin-react-hooks'
-});
+    test('no unknown eslint-plugin-react-hooks rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: reactConfig.rules,
+            pluginRules: hooksPlugin.rules,
+            pluginName: 'eslint-plugin-react-hooks'
+        });
+    });
 
-test('react preset config has no validation errors', checkConfigToHaveNoValidationIssues, reactConfig);
+    test('react preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(reactConfig);
+    });
+});

--- a/test/restricted-syntax.test.js
+++ b/test/restricted-syntax.test.js
@@ -1,5 +1,6 @@
-import test from 'ava';
+import assert from 'node:assert';
 import typescriptParser from '@typescript-eslint/parser';
+import { suite, test } from 'mocha';
 import { RuleTester } from 'eslint';
 import { builtinRules } from 'eslint/use-at-your-own-risk';
 import {
@@ -28,7 +29,7 @@ const typescriptRuleTester = new RuleTester({
     }
 });
 
-function runRuleCases(t, ruleTester, restriction, cases) {
+function runRuleCases(ruleTester, restriction, cases) {
     const valid = cases.valid.map((code) => {
         return { code, options: [ restriction ] };
     });
@@ -44,116 +45,121 @@ function runRuleCases(t, ruleTester, restriction, cases) {
         };
     });
 
-    t.notThrows(() => {
+    assert.doesNotThrow(() => {
         ruleTester.run('no-restricted-syntax', noRestrictedSyntaxRule, { valid, invalid });
     });
 }
 
-test('noClassDeclarationRestriction permits Error subclasses but forbids other classes', (t) => {
-    runRuleCases(t, javascriptRuleTester, noClassDeclarationRestriction, {
-        valid: [
-            'class FooError extends Error {}',
-            'class CustomError extends Error { constructor() { super(); } }',
-            'const x = 1;',
-            'function noop() {}'
-        ],
-        invalid: [
-            'class Foo {}',
-            'class Foo extends Bar {}',
-            'class MyStack extends Stack {}',
-            'class Wrapper extends ns.Error {}'
-        ]
-    });
-});
-
-test('createNoClassDeclarationRestriction with CDK pattern permits CDK base classes', (t) => {
-    const cdkRestriction = createNoClassDeclarationRestriction({
-        allowedSuperClassNamePattern: '/(Error|Construct|Stack|Resource)$/',
-        message: 'CDK class restriction'
+suite('restricted syntax rules', function () {
+    test('noClassDeclarationRestriction permits Error subclasses but forbids other classes', function () {
+        runRuleCases(javascriptRuleTester, noClassDeclarationRestriction, {
+            valid: [
+                'class FooError extends Error {}',
+                'class CustomError extends Error { constructor() { super(); } }',
+                'const x = 1;',
+                'function noop() {}'
+            ],
+            invalid: [
+                'class Foo {}',
+                'class Foo extends Bar {}',
+                'class MyStack extends Stack {}',
+                'class Wrapper extends ns.Error {}'
+            ]
+        });
     });
 
-    runRuleCases(t, javascriptRuleTester, cdkRestriction, {
-        valid: [
-            'class FooError extends Error {}',
-            'class MyConstruct extends Construct {}',
-            'class MyStack extends Stack {}',
-            'class MyNestedStack extends NestedStack {}',
-            'class MyResource extends Resource {}',
-            'class MyBucket extends BaseResource {}'
-        ],
-        invalid: [ 'class Foo {}', 'class MyBucket extends Bucket {}', 'class MyHelper extends Helper {}' ]
-    });
-});
+    test('createNoClassDeclarationRestriction with CDK pattern permits CDK base classes', function () {
+        const cdkRestriction = createNoClassDeclarationRestriction({
+            allowedSuperClassNamePattern: '/(Error|Construct|Stack|Resource)$/',
+            message: 'CDK class restriction'
+        });
 
-test('noSwitchStatementRestriction forbids switch statements', (t) => {
-    runRuleCases(t, javascriptRuleTester, noSwitchStatementRestriction, {
-        valid: [ 'if (x === 1) { a(); } else { b(); }', 'const result = x === 1 ? a() : b();' ],
-        invalid: [
-            'switch (x) { case 1: break; default: break; }',
-            'function pick(x) { switch (x) { case "a": return 1; default: return 0; } }'
-        ]
+        runRuleCases(javascriptRuleTester, cdkRestriction, {
+            valid: [
+                'class FooError extends Error {}',
+                'class MyConstruct extends Construct {}',
+                'class MyStack extends Stack {}',
+                'class MyNestedStack extends NestedStack {}',
+                'class MyResource extends Resource {}',
+                'class MyBucket extends BaseResource {}'
+            ],
+            invalid: [ 'class Foo {}', 'class MyBucket extends Bucket {}', 'class MyHelper extends Helper {}' ]
+        });
     });
-});
 
-test('noEmptyFunctionBodyRestriction forbids empty bodies even with comments', (t) => {
-    runRuleCases(t, javascriptRuleTester, noEmptyFunctionBodyRestriction, {
-        valid: [
-            'function foo() { return 1; }',
-            'const arrow = () => { return 1; };',
-            'const expr = function () { return 1; };',
-            'const lambda = () => 1;'
-        ],
-        invalid: [
-            'function foo() {}',
-            'function foo() { /* intentionally empty */ }',
-            'const arrow = () => {};',
-            'const arrow = () => { /* noop */ };',
-            'const expr = function () {};'
-        ]
+    test('noSwitchStatementRestriction forbids switch statements', function () {
+        runRuleCases(javascriptRuleTester, noSwitchStatementRestriction, {
+            valid: [ 'if (x === 1) { a(); } else { b(); }', 'const result = x === 1 ? a() : b();' ],
+            invalid: [
+                'switch (x) { case 1: break; default: break; }',
+                'function pick(x) { switch (x) { case "a": return 1; default: return 0; } }'
+            ]
+        });
     });
-});
 
-test('noInOperatorRestriction forbids the in operator but permits for-in loops', (t) => {
-    runRuleCases(t, javascriptRuleTester, noInOperatorRestriction, {
-        valid: [
-            'if (Object.hasOwn(bar, "foo")) {}',
-            'for (const key in bar) {}',
-            'const x = a < b;'
-        ],
-        invalid: [
-            'if ("foo" in bar) {}',
-            'const has = "foo" in bar;',
-            'function check(obj) { return "key" in obj; }'
-        ]
+    test('noEmptyFunctionBodyRestriction forbids empty bodies even with comments', function () {
+        runRuleCases(javascriptRuleTester, noEmptyFunctionBodyRestriction, {
+            valid: [
+                'function foo() { return 1; }',
+                'const arrow = () => { return 1; };',
+                'const expr = function () { return 1; };',
+                'const lambda = () => 1;'
+            ],
+            invalid: [
+                'function foo() {}',
+                'function foo() { /* intentionally empty */ }',
+                'const arrow = () => {};',
+                'const arrow = () => { /* noop */ };',
+                'const expr = function () {};'
+            ]
+        });
     });
-});
 
-test('noTsEnumDeclarationRestriction forbids TS enum declarations', (t) => {
-    runRuleCases(t, typescriptRuleTester, noTsEnumDeclarationRestriction, {
-        valid: [ 'type Color = "red" | "green" | "blue";', 'const Color = { red: "red", green: "green" } as const;' ],
-        invalid: [ 'enum Color { Red, Green, Blue }', 'const enum Status { Active, Inactive }' ]
+    test('noInOperatorRestriction forbids the in operator but permits for-in loops', function () {
+        runRuleCases(javascriptRuleTester, noInOperatorRestriction, {
+            valid: [
+                'if (Object.hasOwn(bar, "foo")) {}',
+                'for (const key in bar) {}',
+                'const x = a < b;'
+            ],
+            invalid: [
+                'if ("foo" in bar) {}',
+                'const has = "foo" in bar;',
+                'function check(obj) { return "key" in obj; }'
+            ]
+        });
     });
-});
 
-test('noInlineSignatureTypeLiteralRestriction forbids inline object types in function signatures', (t) => {
-    runRuleCases(t, typescriptRuleTester, noInlineSignatureTypeLiteralRestriction, {
-        valid: [
-            'function foo(x: NamedType): NamedType { return x; }',
-            'function foo(x: string | number): boolean { return true; }',
-            'const arrow = (x: NamedType): NamedType => x;',
-            'type Handler = (event: NamedEvent) => NamedResult;',
-            'function foo(): void {}',
-            'const obj: { a: number } = { a: 1 };',
-            'function foo(): NamedType { const inner: { b: string } = { b: "x" }; return inner as unknown as NamedType; }'
-        ],
-        invalid: [
-            'function foo(x: { a: number }): void {}',
-            'function foo(): { b: string } { return { b: "x" }; }',
-            { code: 'const arrow = (x: { a: number }): { b: string } => ({ b: "x" });', count: 2 },
-            'function foo(x: { a: number } = { a: 1 }): void {}',
-            'function foo({ x }: { x: number }): void {}',
-            'type Handler = (event: { id: string }) => void;',
-            'declare function foo(x: { a: number }): void;'
-        ]
+    test('noTsEnumDeclarationRestriction forbids TS enum declarations', function () {
+        runRuleCases(typescriptRuleTester, noTsEnumDeclarationRestriction, {
+            valid: [
+                'type Color = "red" | "green" | "blue";',
+                'const Color = { red: "red", green: "green" } as const;'
+            ],
+            invalid: [ 'enum Color { Red, Green, Blue }', 'const enum Status { Active, Inactive }' ]
+        });
+    });
+
+    test('noInlineSignatureTypeLiteralRestriction forbids inline object types in function signatures', function () {
+        runRuleCases(typescriptRuleTester, noInlineSignatureTypeLiteralRestriction, {
+            valid: [
+                'function foo(x: NamedType): NamedType { return x; }',
+                'function foo(x: string | number): boolean { return true; }',
+                'const arrow = (x: NamedType): NamedType => x;',
+                'type Handler = (event: NamedEvent) => NamedResult;',
+                'function foo(): void {}',
+                'const obj: { a: number } = { a: 1 };',
+                'function foo(): NamedType { const inner: { b: string } = { b: "x" }; return inner as unknown as NamedType; }'
+            ],
+            invalid: [
+                'function foo(x: { a: number }): void {}',
+                'function foo(): { b: string } { return { b: "x" }; }',
+                { code: 'const arrow = (x: { a: number }): { b: string } => ({ b: "x" });', count: 2 },
+                'function foo(x: { a: number } = { a: 1 }): void {}',
+                'function foo({ x }: { x: number }): void {}',
+                'type Handler = (event: { id: string }) => void;',
+                'declare function foo(x: { a: number }): void;'
+            ]
+        });
     });
 });

--- a/test/rules-configuration.js
+++ b/test/rules-configuration.js
@@ -1,5 +1,5 @@
+import assert from 'node:assert';
 import eslintCorePresets from '@eslint/js';
-import test from 'ava';
 import { Linter } from 'eslint';
 import ts from 'typescript';
 import { testRuleSet } from '../configs/presets/test-base/test-base.js';
@@ -32,18 +32,22 @@ function isRuleConfigured(ruleConfigSet, ruleName) {
     return configuredRuleNames.includes(ruleName);
 }
 
-export const checkAllCoreRulesConfigured = test.macro((t, testCase) => {
+export function checkAllCoreRulesConfigured(testCase) {
     const { ruleConfigSet } = testCase;
     const ruleNames = Object.keys(eslintCorePresets.configs.all.rules);
 
-    t.not(ruleNames.length, 0, 'ESLint core rules not found');
+    assert.notStrictEqual(ruleNames.length, 0, 'ESLint core rules not found');
 
     ruleNames.forEach((ruleName) => {
-        t.true(isRuleConfigured(ruleConfigSet, ruleName), `ESLint core rule "${ruleName}" not configured`);
+        assert.strictEqual(
+            isRuleConfigured(ruleConfigSet, ruleName),
+            true,
+            `ESLint core rule "${ruleName}" not configured`
+        );
     });
-});
+}
 
-export const checkUnknownCoreRulesAreNotConfigured = test.macro((t, testCase) => {
+export function checkUnknownCoreRulesAreNotConfigured(testCase) {
     const { ruleConfigSet } = testCase;
     const allCoreRuleNames = Object.keys(eslintCorePresets.configs.all.rules);
     const configuredRuleNames = Object.keys(ruleConfigSet);
@@ -52,16 +56,20 @@ export const checkUnknownCoreRulesAreNotConfigured = test.macro((t, testCase) =>
     });
 
     configuredCoreRuleNames.forEach((ruleName) => {
-        t.true(allCoreRuleNames.includes(ruleName), `ESLint core rule "${ruleName}" configured, but doesn’t not exist`);
+        assert.strictEqual(
+            allCoreRuleNames.includes(ruleName),
+            true,
+            `ESLint core rule "${ruleName}" configured, but doesn’t not exist`
+        );
     });
-});
+}
 
-export const checkAllPluginRulesConfigured = test.macro((t, testCase) => {
+export function checkAllPluginRulesConfigured(testCase) {
     const { ruleConfigSet, pluginRules, pluginName, rulesToExclude = [] } = testCase;
     const ruleNames = Object.keys(pluginRules);
     const shortPluginName = extractShortName(pluginName);
 
-    t.not(ruleNames.length, 0, 'Plugin rules are empty');
+    assert.notStrictEqual(ruleNames.length, 0, 'Plugin rules are empty');
 
     ruleNames
         .filter((ruleName) => {
@@ -73,15 +81,15 @@ export const checkAllPluginRulesConfigured = test.macro((t, testCase) => {
             const isConfigured = isRuleConfigured(ruleConfigSet, shortPluginRuleName);
 
             const shouldRuleBeConfigured = !isRuleDeprecated(rule);
-            t.is(
+            assert.strictEqual(
                 isConfigured,
                 shouldRuleBeConfigured,
                 `Rule ${shortPluginRuleName} ${shouldRuleBeConfigured ? 'not configured' : 'is deprecated'}`
             );
         });
-});
+}
 
-export const checkUnknownPluginRulesAreNotConfigured = test.macro((t, testCase) => {
+export function checkUnknownPluginRulesAreNotConfigured(testCase) {
     const { ruleConfigSet, pluginRules, pluginName } = testCase;
     const shortPluginName = extractShortName(pluginName);
     const pluginRuleNames = Object
@@ -93,7 +101,7 @@ export const checkUnknownPluginRulesAreNotConfigured = test.macro((t, testCase) 
             return `${shortPluginName}/${ruleName}`;
         });
 
-    t.not(pluginRuleNames.length, 0, 'Plugin rules are empty');
+    assert.notStrictEqual(pluginRuleNames.length, 0, 'Plugin rules are empty');
 
     const configuredRuleNames = Object.keys(ruleConfigSet);
     const configuredPluginRuleNames = configuredRuleNames.filter((ruleName) => {
@@ -101,9 +109,9 @@ export const checkUnknownPluginRulesAreNotConfigured = test.macro((t, testCase) 
     });
 
     configuredPluginRuleNames.forEach((ruleName) => {
-        t.true(pluginRuleNames.includes(ruleName), `Rule ${ruleName} can be removed`);
+        assert.strictEqual(pluginRuleNames.includes(ruleName), true, `Rule ${ruleName} can be removed`);
     });
-});
+}
 
 export function mergeConfigRules(config) {
     if (Array.isArray(config)) {
@@ -114,7 +122,7 @@ export function mergeConfigRules(config) {
     return config.rules ?? {};
 }
 
-export const checkConfigToHaveNoValidationIssues = test.macro((t, config) => {
+export function checkConfigToHaveNoValidationIssues(config) {
     const linter = new Linter({ configType: 'flat' });
 
     const sourceFile = ts.createSourceFile('/foo.js', 'foo();', ts.ScriptTarget.Latest);
@@ -145,24 +153,24 @@ export const checkConfigToHaveNoValidationIssues = test.macro((t, config) => {
 
     const verifiableConfig = Array.isArray(config) ? config.map(injectProgram) : injectProgram(config);
 
-    t.notThrows(() => {
+    assert.doesNotThrow(() => {
         linter.verify('foo();', verifiableConfig, '/foo.js');
     }, 'Linter.verify() failed for the given config');
-});
+}
 
-export const checkConfigLanguageOptions = test.macro((t, testCase) => {
+export function checkConfigLanguageOptions(testCase) {
     const { configLanguageOptions, languageOptions } = testCase;
 
-    t.deepEqual(configLanguageOptions, languageOptions);
-});
+    assert.deepStrictEqual(configLanguageOptions, languageOptions);
+}
 
-export const checkAllTestRulesConfigured = test.macro((t, testCase) => {
+export function checkAllTestRulesConfigured(testCase) {
     const { ruleConfigSet } = testCase;
 
     const testRuleNames = Object.keys(testRuleSet.rules);
     const rulesFromConfigKeys = Object.keys(ruleConfigSet);
 
-    t.not(rulesFromConfigKeys.length, 0, 'Plugin rules are empty');
+    assert.notStrictEqual(rulesFromConfigKeys.length, 0, 'Plugin rules are empty');
 
     const remainingRulesKeys = rulesFromConfigKeys.filter((ruleName) => {
         return testRuleNames.includes(ruleName);
@@ -171,10 +179,10 @@ export const checkAllTestRulesConfigured = test.macro((t, testCase) => {
     const actual = remainingRulesKeys;
     const expected = testRuleNames;
 
-    t.deepEqual(actual, expected, 'Common test rules could not be found');
-});
+    assert.deepStrictEqual(actual, expected, 'Common test rules could not be found');
+}
 
-export const checkAdditionalRulesConfigured = test.macro((t, testCase) => {
+export function checkAdditionalRulesConfigured(testCase) {
     const { ruleConfigSet, additionalRules } = testCase;
 
     const additionalRulesNames = Object.keys(additionalRules);
@@ -182,15 +190,15 @@ export const checkAdditionalRulesConfigured = test.macro((t, testCase) => {
         return additionalRulesNames.includes(ruleName);
     });
 
-    t.not(additionalRulesFromRuleConfigSet.length, 0, 'Additional plugin rules are not defined');
+    assert.notStrictEqual(additionalRulesFromRuleConfigSet.length, 0, 'Additional plugin rules are not defined');
 
     additionalRulesFromRuleConfigSet.forEach(([ ruleName, ruleSetting ]) => {
         const expectedRuleSetting = additionalRules[ruleName];
 
-        t.deepEqual(
+        assert.deepStrictEqual(
             expectedRuleSetting,
             ruleSetting,
             `Rule ${ruleName} is not set to ${JSON.stringify(expectedRuleSetting)}`
         );
     });
-});
+}

--- a/test/typescript.test.js
+++ b/test/typescript.test.js
@@ -1,6 +1,6 @@
 import typescriptPlugin from '@typescript-eslint/eslint-plugin';
 import typescriptParser from '@typescript-eslint/parser';
-import test from 'ava';
+import { suite, test } from 'mocha';
 import functionalPlugin from 'eslint-plugin-functional';
 import { rules as perfectionistRules } from 'eslint-plugin-perfectionist';
 import { typescriptConfig } from '../configs/presets/typescript/typescript.js';
@@ -11,72 +11,90 @@ import {
     checkUnknownPluginRulesAreNotConfigured
 } from './rules-configuration.js';
 
-test('typescript preset config has the correct language options defined', checkConfigLanguageOptions, {
-    configLanguageOptions: typescriptConfig.languageOptions,
-    languageOptions: {
-        parser: typescriptParser,
-        parserOptions: {
-            warnOnUnsupportedTypeScriptVersion: false,
-            sourceType: 'module',
-            ecmaFeatures: {
-                jsx: false,
-                globalReturn: false
-            },
-            projectService: true
-        }
-    }
-});
+suite('typescript preset', function () {
+    test('typescript preset config has the correct language options defined', function () {
+        checkConfigLanguageOptions({
+            configLanguageOptions: typescriptConfig.languageOptions,
+            languageOptions: {
+                parser: typescriptParser,
+                parserOptions: {
+                    warnOnUnsupportedTypeScriptVersion: false,
+                    sourceType: 'module',
+                    ecmaFeatures: {
+                        jsx: false,
+                        globalReturn: false
+                    },
+                    projectService: true
+                }
+            }
+        });
+    });
 
-test('all @typescript-eslint/eslint-plugin rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: typescriptConfig.rules,
-    pluginRules: typescriptPlugin.rules,
-    rulesToExclude: [
-        'brace-style',
-        'func-call-spacing',
-        'indent',
-        'quotes',
-        'semi',
-        'no-unused-expressions',
-        'comma-spacing',
-        'keyword-spacing',
-        'member-delimiter-style',
-        'no-extra-parens',
-        'type-annotation-spacing',
-        'lines-between-class-members',
-        'comma-dangle',
-        'key-spacing'
-    ],
-    pluginName: '@typescript-eslint/eslint-plugin'
-});
+    test('all @typescript-eslint/eslint-plugin rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: typescriptConfig.rules,
+            pluginRules: typescriptPlugin.rules,
+            rulesToExclude: [
+                'brace-style',
+                'func-call-spacing',
+                'indent',
+                'quotes',
+                'semi',
+                'no-unused-expressions',
+                'comma-spacing',
+                'keyword-spacing',
+                'member-delimiter-style',
+                'no-extra-parens',
+                'type-annotation-spacing',
+                'lines-between-class-members',
+                'comma-dangle',
+                'key-spacing'
+            ],
+            pluginName: '@typescript-eslint/eslint-plugin'
+        });
+    });
 
-test('no unknown @typescript-eslint/eslint-plugin rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: typescriptConfig.rules,
-    pluginRules: typescriptPlugin.rules,
-    pluginName: '@typescript-eslint/eslint-plugin'
-});
+    test('no unknown @typescript-eslint/eslint-plugin rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: typescriptConfig.rules,
+            pluginRules: typescriptPlugin.rules,
+            pluginName: '@typescript-eslint/eslint-plugin'
+        });
+    });
 
-test('all eslint-plugin-functional rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: typescriptConfig.rules,
-    pluginRules: functionalPlugin.rules,
-    pluginName: 'eslint-plugin-functional'
-});
+    test('all eslint-plugin-functional rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: typescriptConfig.rules,
+            pluginRules: functionalPlugin.rules,
+            pluginName: 'eslint-plugin-functional'
+        });
+    });
 
-test('no unknown eslint-plugin-functional rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: typescriptConfig.rules,
-    pluginRules: functionalPlugin.rules,
-    pluginName: 'eslint-plugin-functional'
-});
+    test('no unknown eslint-plugin-functional rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: typescriptConfig.rules,
+            pluginRules: functionalPlugin.rules,
+            pluginName: 'eslint-plugin-functional'
+        });
+    });
 
-test('all eslint-plugin-perfectionist rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: typescriptConfig.rules,
-    pluginRules: perfectionistRules,
-    pluginName: 'eslint-plugin-perfectionist'
-});
+    test('all eslint-plugin-perfectionist rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: typescriptConfig.rules,
+            pluginRules: perfectionistRules,
+            pluginName: 'eslint-plugin-perfectionist'
+        });
+    });
 
-test('no unknown eslint-plugin-perfectionist rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: typescriptConfig.rules,
-    pluginRules: perfectionistRules,
-    pluginName: 'eslint-plugin-perfectionist'
-});
+    test('no unknown eslint-plugin-perfectionist rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: typescriptConfig.rules,
+            pluginRules: perfectionistRules,
+            pluginName: 'eslint-plugin-perfectionist'
+        });
+    });
 
-test('typescript preset config has no validation errors', checkConfigToHaveNoValidationIssues, typescriptConfig);
+    test('typescript preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(typescriptConfig);
+    });
+});

--- a/test/vitest.test.js
+++ b/test/vitest.test.js
@@ -1,5 +1,5 @@
 import vitestPlugin from '@vitest/eslint-plugin';
-import test from 'ava';
+import { suite, test } from 'mocha';
 import { vitestConfig } from '../configs/presets/vitest/vitest.js';
 import {
     checkAllPluginRulesConfigured,
@@ -8,20 +8,30 @@ import {
     checkUnknownPluginRulesAreNotConfigured
 } from './rules-configuration.js';
 
-test('all @vitest/eslint-plugin rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: vitestConfig.rules,
-    pluginRules: vitestPlugin.rules,
-    pluginName: '@vitest/eslint-plugin'
-});
+suite('vitest preset', function () {
+    test('all @vitest/eslint-plugin rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: vitestConfig.rules,
+            pluginRules: vitestPlugin.rules,
+            pluginName: '@vitest/eslint-plugin'
+        });
+    });
 
-test('no unknown @vitest/eslint-plugin rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: vitestConfig.rules,
-    pluginRules: vitestPlugin.rules,
-    pluginName: '@vitest/eslint-plugin'
-});
+    test('no unknown @vitest/eslint-plugin rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: vitestConfig.rules,
+            pluginRules: vitestPlugin.rules,
+            pluginName: '@vitest/eslint-plugin'
+        });
+    });
 
-test('all common test rules are configured', checkAllTestRulesConfigured, {
-    ruleConfigSet: vitestConfig.rules
-});
+    test('all common test rules are configured', function () {
+        checkAllTestRulesConfigured({
+            ruleConfigSet: vitestConfig.rules
+        });
+    });
 
-test('vitest preset config has no validation errors', checkConfigToHaveNoValidationIssues, vitestConfig);
+    test('vitest preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(vitestConfig);
+    });
+});

--- a/test/vue-ts.test.js
+++ b/test/vue-ts.test.js
@@ -1,5 +1,6 @@
+import assert from 'node:assert';
 import typescriptParser from '@typescript-eslint/parser';
-import test from 'ava';
+import { suite, test } from 'mocha';
 import vuePlugin from 'eslint-plugin-vue';
 import globals from 'globals';
 import vueParser from 'vue-eslint-parser';
@@ -11,39 +12,49 @@ import {
     checkUnknownPluginRulesAreNotConfigured
 } from './rules-configuration.js';
 
-test('vue preset config has the correct language options defined', checkConfigLanguageOptions, {
-    configLanguageOptions: vueConfig.languageOptions,
-    languageOptions: {
-        parser: vueParser,
-        globals: globals['shared-node-browser'],
-        parserOptions: {
-            parser: typescriptParser,
-            extraFileExtensions: [ '.vue' ],
-            warnOnUnsupportedTypeScriptVersion: false,
-            sourceType: 'module',
-            ecmaFeatures: {
-                jsx: false,
-                globalReturn: false
-            },
-            projectService: true
-        }
-    }
-});
+suite('vue-ts preset', function () {
+    test('vue preset config has the correct language options defined', function () {
+        checkConfigLanguageOptions({
+            configLanguageOptions: vueConfig.languageOptions,
+            languageOptions: {
+                parser: vueParser,
+                globals: globals['shared-node-browser'],
+                parserOptions: {
+                    parser: typescriptParser,
+                    extraFileExtensions: [ '.vue' ],
+                    warnOnUnsupportedTypeScriptVersion: false,
+                    sourceType: 'module',
+                    ecmaFeatures: {
+                        jsx: false,
+                        globalReturn: false
+                    },
+                    projectService: true
+                }
+            }
+        });
+    });
 
-test('vue preset config has the correct processor set', (t) => {
-    t.is(vueConfig.processor, 'vue/vue');
-});
+    test('vue preset config has the correct processor set', function () {
+        assert.strictEqual(vueConfig.processor, 'vue/vue');
+    });
 
-test('all eslint-plugin-vue rules are configured', checkAllPluginRulesConfigured, {
-    ruleConfigSet: vueConfig.rules,
-    pluginRules: vuePlugin.rules,
-    pluginName: 'eslint-plugin-vue'
-});
+    test('all eslint-plugin-vue rules are configured', function () {
+        checkAllPluginRulesConfigured({
+            ruleConfigSet: vueConfig.rules,
+            pluginRules: vuePlugin.rules,
+            pluginName: 'eslint-plugin-vue'
+        });
+    });
 
-test('no unknown eslint-plugin-vue rules are configured', checkUnknownPluginRulesAreNotConfigured, {
-    ruleConfigSet: vueConfig.rules,
-    pluginRules: vuePlugin.rules,
-    pluginName: 'eslint-plugin-vue'
-});
+    test('no unknown eslint-plugin-vue rules are configured', function () {
+        checkUnknownPluginRulesAreNotConfigured({
+            ruleConfigSet: vueConfig.rules,
+            pluginRules: vuePlugin.rules,
+            pluginName: 'eslint-plugin-vue'
+        });
+    });
 
-test('vue preset config has no validation errors', checkConfigToHaveNoValidationIssues, vueConfig);
+    test('vue preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(vueConfig);
+    });
+});


### PR DESCRIPTION
Replace AVA with Mocha as the test runner for this repository.

In addition the unit tests are now running twice as fast 🙂 Instead of 22 seconds they take 11 seconds now. 