### PR TITLE
Ship dprint formatter packages as base preset runtime dependencies

### DIFF
--- a/configs/presets/base/base.js
+++ b/configs/presets/base/base.js
@@ -1,3 +1,9 @@
+/* eslint-disable import/no-unassigned-import -- side-effect imports surface the dprint formatter packages to Packtory's static dependency scanner so they end up as runtime dependencies of the published package */
+import '@dprint/json';
+import '@dprint/markdown';
+import '@dprint/toml';
+import '@dprint/typescript';
+/* eslint-enable import/no-unassigned-import -- end of Packtory-visibility imports */
 import dprintPlugin from '@ben_12/eslint-plugin-dprint';
 import simpleParser from '@ben_12/eslint-simple-parser';
 import { baseSharedConfig } from './base-shared.js';

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -3,6 +3,7 @@
         "enormora",
         "hashbang",
         "astro",
+        "packtory",
         "scopedslots",
         "canonicalurl",
         "fetchcontent",


### PR DESCRIPTION
`@ben_12/eslint-plugin-dprint` loads its WASM formatters via dynamic require() of optional peer dependencies at module-load time. Packtory's static scanner doesn't follow those, so the published @enormora/eslint-config-base never listed the dprint formatter packages in its dependencies. Consumers saw "Plugin not found: @dprint/<lang>" warnings on every lint run, and the matching dprint/<lang> rules silently became no-ops because the formatter buffer was never loaded.

Declare side-effect imports for the four dprint formatter packages that ship a JS entrypoint (@dprint/json, @dprint/markdown, @dprint/toml, @dprint/typescript) so Packtory picks them up as runtime dependencies.

dprint-plugin-yaml is left out because it exposes only plugin.wasm and package.json — no JS entry that ts-morph can resolve as a source file — and Packtory forbids declaring dependencies via
additionalPackageJsonAttributes. The yaml warning will persist and dprint/yaml stays a silent no-op in consumer repos until an upstream plugin API lets us pass a formatter instance explicitly;