### PR TITLE
Extend immutability fixer to cover Record, index signatures, and multi-property object literals

### DIFF
--- a/configs/presets/typescript/typescript.js
+++ b/configs/presets/typescript/typescript.js
@@ -397,6 +397,24 @@ export const typescriptConfig = {
                         {
                             pattern: '^(Map|Set)<(.+)>$',
                             replace: 'Readonly$1<$2>'
+                        },
+                        {
+                            pattern: '^Record<(.+)>$',
+                            replace: 'Readonly<Record<$1>>'
+                        },
+                        {
+                            pattern: '^\\{ \\[([^\\]]+)\\]: (.+?);? \\}$',
+                            replace: '{ readonly [$1]: $2; }'
+                        },
+                        // Iterative one-property-per-pass prefix for object
+                        // literal types. ESLint --fix runs the rule repeatedly
+                        // until stable, so this prefixes one property each
+                        // pass. Anchoring at "^{ " or "; " means only property
+                        // boundaries inside an object type match; function
+                        // parameters are inside "(" and never matched.
+                        {
+                            pattern: '(^\\{ |; )(?!readonly )([\\w$]+\\??: )',
+                            replace: '$1readonly $2'
                         }
                     ]
                 },
@@ -434,6 +452,18 @@ export const typescriptConfig = {
                             {
                                 pattern: '^(Map|Set)<(.+)>$',
                                 replace: 'Readonly$1<$2>'
+                            },
+                            {
+                                pattern: '^Record<(.+)>$',
+                                replace: 'Readonly<Record<$1>>'
+                            },
+                            {
+                                pattern: '^\\{ \\[([^\\]]+)\\]: (.+?);? \\}$',
+                                replace: '{ readonly [$1]: $2; }'
+                            },
+                            {
+                                pattern: '(^\\{ |; )(?!readonly )([\\w$]+\\??: )',
+                                replace: '$1readonly $2'
                             }
                         ]
                     }


### PR DESCRIPTION
Adds three patterns to the configured fixers for functional/prefer-immutable-types and functional/type-declaration-immutability:

- Record<K, V> → Readonly<Record<K, V>>
- { [k: K]: V } → { readonly [k: K]: V; }
- Multi-property object literals: prefixes one property per ESLint --fix pass, anchored at "^{ " or "; " so function-type parameters inside "()" are never matched.