### PR TITLE
Add withCspellWords helper for project-specific words

### DIFF
--- a/configs/presets/base/base-shared.js
+++ b/configs/presets/base/base-shared.js
@@ -20,6 +20,31 @@ const restrictedSyntaxPlugin = createRestrictedSyntaxPlugin([
     'no-in-operator'
 ]);
 
+export const cspellSpellcheckerOptions = {
+    autoFix: false,
+    numSuggestions: 3,
+    generateSuggestions: true,
+    ignoreImports: true,
+    ignoreImportProperties: true,
+    checkIdentifiers: true,
+    checkStrings: true,
+    checkStringTemplates: true,
+    checkJSXText: true,
+    checkComments: true,
+    cspell: {
+        words: [],
+        ignoreWords: [],
+        flagWords: [],
+        ignoreRegExpList: [],
+        includeRegExpList: [],
+        allowCompoundWords: true,
+        import: [],
+        dictionaries: []
+    },
+    customWordListFile: undefined,
+    debugMode: false
+};
+
 export const baseSharedConfig = {
     languageOptions: {
         ecmaVersion,
@@ -425,32 +450,6 @@ export const baseSharedConfig = {
         'import/no-rename-default': 'off',
         'import/prefer-namespace-import': 'off',
 
-        '@cspell/spellchecker': [
-            'error',
-            {
-                autoFix: false,
-                numSuggestions: 3,
-                generateSuggestions: true,
-                ignoreImports: true,
-                ignoreImportProperties: true,
-                checkIdentifiers: true,
-                checkStrings: true,
-                checkStringTemplates: true,
-                checkJSXText: true,
-                checkComments: true,
-                cspell: {
-                    words: [],
-                    ignoreWords: [],
-                    flagWords: [],
-                    ignoreRegExpList: [],
-                    includeRegExpList: [],
-                    allowCompoundWords: true,
-                    import: [],
-                    dictionaries: []
-                },
-                customWordListFile: undefined,
-                debugMode: false
-            }
-        ]
+        '@cspell/spellchecker': [ 'error', cspellSpellcheckerOptions ]
     }
 };

--- a/configs/presets/base/base.js
+++ b/configs/presets/base/base.js
@@ -63,7 +63,7 @@ export const baseConfig = [
     dprintTomlConfig
 ];
 
-/* eslint-disable no-barrel-files/no-barrel-files -- expose dprint configs as public API so consumers can spread them when overriding individual options */
+/* eslint-disable no-barrel-files/no-barrel-files -- expose dprint configs and cspell helper as public API so consumers can spread or call them when customizing */
 export {
     jsonDprintConfig,
     markdownDprintConfig,
@@ -71,4 +71,5 @@ export {
     typescriptDprintConfig,
     yamlDprintConfig
 } from './dprint-config.js';
+export { withCspellWords } from './cspell-config.js';
 /* eslint-enable no-barrel-files/no-barrel-files -- end of public re-exports */

--- a/configs/presets/base/cspell-config.js
+++ b/configs/presets/base/cspell-config.js
@@ -1,0 +1,18 @@
+import { cspellSpellcheckerOptions } from './base-shared.js';
+
+export function withCspellWords(words) {
+    return {
+        rules: {
+            '@cspell/spellchecker': [
+                'error',
+                {
+                    ...cspellSpellcheckerOptions,
+                    cspell: {
+                        ...cspellSpellcheckerOptions.cspell,
+                        words: [ ...cspellSpellcheckerOptions.cspell.words, ...words ]
+                    }
+                }
+            ]
+        }
+    };
+}

--- a/test/cspell-helper.test.js
+++ b/test/cspell-helper.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { cspellSpellcheckerOptions } from '../configs/presets/base/base-shared.js';
+import { withCspellWords } from '../configs/presets/base/cspell-config.js';
+
+function cloneOptions(value) {
+    if (Array.isArray(value)) {
+        return value.map((item) => {
+            return cloneOptions(item);
+        });
+    }
+    if (value !== null && typeof value === 'object') {
+        const result = {};
+        for (const key of Object.keys(value)) {
+            result[key] = cloneOptions(value[key]);
+        }
+        return result;
+    }
+    return value;
+}
+
+suite('withCspellWords helper', function () {
+    test('returns a config block with the @cspell/spellchecker rule at error severity', function () {
+        const block = withCspellWords([ 'enormora' ]);
+        const [ severity ] = block.rules['@cspell/spellchecker'];
+        assert.strictEqual(severity, 'error');
+    });
+
+    test('appends the provided words to the base cspell.words list', function () {
+        const block = withCspellWords([ 'enormora', 'packtory' ]);
+        const [ , options ] = block.rules['@cspell/spellchecker'];
+        assert.deepStrictEqual(options.cspell.words, [ 'enormora', 'packtory' ]);
+    });
+
+    test('preserves the remaining options from the base config', function () {
+        const block = withCspellWords([ 'foo' ]);
+        const [ , options ] = block.rules['@cspell/spellchecker'];
+        const expected = {
+            ...cspellSpellcheckerOptions,
+            cspell: { ...cspellSpellcheckerOptions.cspell, words: [ 'foo' ] }
+        };
+        assert.deepStrictEqual(options, expected);
+    });
+
+    test('does not mutate the shared base options', function () {
+        const before = cloneOptions(cspellSpellcheckerOptions);
+        withCspellWords([ 'mutates' ]);
+        assert.deepStrictEqual(cspellSpellcheckerOptions, before);
+    });
+
+    test('exposes only the rules key so it can be spread alongside other config blocks', function () {
+        const block = withCspellWords([ 'foo' ]);
+        assert.deepStrictEqual(Object.keys(block), [ 'rules' ]);
+    });
+});


### PR DESCRIPTION
Expose `withCspellWords(words)` from `@enormora/eslint-config-base` so consumers can add project-specific cspell words at error severity without redeclaring the full ~25-line `@cspell/spellchecker` rule config every time.

The shared options object is extracted into `cspellSpellcheckerOptions` in `base-shared.js` and reused by both the base rule and the helper, so the two can never drift apart.

## Usage

```js
import { baseConfig, withCspellWords } from '@enormora/eslint-config-base';

export default [
    ...baseConfig,
    withCspellWords([ 'enormora', 'packtory' ])
];
```