### PR TITLE
Disable sonarjs/function-return-type in TypeScript preset

### DIFF
--- a/configs/presets/typescript/typescript.js
+++ b/configs/presets/typescript/typescript.js
@@ -184,6 +184,10 @@ export const typescriptConfig = {
                 allowTypedFunctionExpressions: true
             }
         ],
+        // TS already validates return types, and the SonarJS heuristic
+        // misfires on intentional tagged-union returns (e.g. `Value | Sentinel`)
+        // even when expressed as a single named alias.
+        'sonarjs/function-return-type': 'off',
         ...configureWrappedCoreRule('max-params'),
         '@typescript-eslint/member-ordering': 'error',
         ...configureWrappedCoreRule('no-array-constructor'),


### PR DESCRIPTION
## Summary
- The SonarJS rule misfires on intentional tagged-union returns (e.g. `Value | Sentinel`), even when the return is a single named alias — forcing awkward workarounds like identity wrappers that just launder the type.
- TypeScript already validates return types, and `@typescript-eslint/explicit-function-return-type` forces the signature to be written down, so the SonarJS heuristic adds noise without catching real bugs in TS.
- The rule remains active for plain JS files via the best-practices rule set, where stronger type signatures aren't available.