### PR TITLE
Align dprint-markdown settings with eslint-plugin-mocha

### DIFF
--- a/configs/presets/base/dprint-config.js
+++ b/configs/presets/base/dprint-config.js
@@ -73,7 +73,10 @@ export const jsonDprintConfig = {
 
 export const markdownDprintConfig = {
     lineWidth,
-    newLineKind: 'lf'
+    newLineKind: 'lf',
+    textWrap: 'maintain',
+    emphasisKind: 'underscores',
+    strongKind: 'asterisks'
 };
 
 export const yamlDprintConfig = {


### PR DESCRIPTION
## Summary
- Add `textWrap: 'maintain'`, `emphasisKind: 'underscores'`, and `strongKind: 'asterisks'` to `markdownDprintConfig` so dprint-markdown formats markdown the same way as the [`lo1tuma/eslint-plugin-mocha`](https://github.com/lo1tuma/eslint-plugin-mocha) repository's `dprint.json`.
- `textWrap: 'maintain'` and `emphasisKind: 'underscores'` happen to match `@dprint/markdown`'s defaults, but stating them explicitly keeps intent visible. `strongKind: 'asterisks'` is the active divergence from the plugin default of `underscores`.