### PR TITLE
Extend `no-warning-comments` to flag more tool disable markers

### DIFF
--- a/configs/presets/base/base-shared.js
+++ b/configs/presets/base/base-shared.js
@@ -185,7 +185,23 @@ export const baseSharedConfig = {
         'no-warning-comments': [
             'error',
             {
-                terms: [ 'todo', 'fixme', 'wtf', 'falls through', 'istanbul', 'c8' ],
+                terms: [
+                    'todo',
+                    'fixme',
+                    'wtf',
+                    'falls through',
+                    'istanbul',
+                    'c8',
+                    'v8 ignore',
+                    'node:coverage',
+                    'prettier-ignore',
+                    'dprint-ignore',
+                    'cspell:disable',
+                    'cspell:ignore',
+                    'cspell:words',
+                    'Stryker disable',
+                    'Stryker restore'
+                ],
                 location: 'anywhere'
             }
         ],


### PR DESCRIPTION
Extends the `no-warning-comments` terms in `configs/presets/base/base-shared.js` so common tool-bypass directives are flagged when they end up in source comments.

### Added terms

- Formatter ignores: `prettier-ignore`, `dprint-ignore`
- `cspell` directives: `cspell:disable`, `cspell:ignore`, `cspell:words`
- Coverage ignores: `v8 ignore`, `node:coverage`
- Stryker mutation switches: `Stryker disable`, `Stryker restore`

### Out of scope

- TypeScript pragmas (`@ts-ignore`, `@ts-nocheck`, `@ts-expect-error`) are already banned by `@typescript-eslint/ban-ts-comment` in `configs/presets/typescript/typescript.js`.
- Other-linter disables (`tslint:disable`, `stylelint-disable`, `biome-ignore`, etc.) are not relevant here since this project only uses ESLint, and `eslint-disable` is covered by dedicated rules.