### PR TITLE
Allow `Stage` and `App` superclasses in aws-cdk class restriction

### DIFF
--- a/configs/presets/aws-cdk/aws-cdk.js
+++ b/configs/presets/aws-cdk/aws-cdk.js
@@ -1,7 +1,7 @@
 import { createNoClassDeclarationRestriction } from '../../rule-sets/restricted-syntax.js';
 
 const cdkClassDeclarationRestriction = createNoClassDeclarationRestriction({
-    allowedSuperClassNamePattern: '/(Error|Construct|Stack|Resource)$/',
+    allowedSuperClassNamePattern: '/(Error|Construct|Stack|Stage|App|Resource)$/',
     message: 'Class declarations are not allowed except for extending errors or CDK constructs.'
 });
 

--- a/configs/presets/aws-cdk/aws-cdk.md
+++ b/configs/presets/aws-cdk/aws-cdk.md
@@ -6,7 +6,7 @@ Config preset for AWS CDK projects. Disables a small set of rules that conflict 
 
 ## What it disables and why
 
-- `no-restricted-syntax` — re-applies the switch and TS enum bans, and keeps the class-declaration ban but widens its allowlist so classes whose superclass name ends in `Error`, `Construct`, `Stack`, or `Resource` (e.g. `MyStack extends Stack`, custom errors) are permitted.
+- `no-restricted-syntax` — re-applies the switch and TS enum bans, and keeps the class-declaration ban but widens its allowlist so classes whose superclass name ends in `Error`, `Construct`, `Stack`, `Stage`, `App`, or `Resource` (e.g. `MyStack extends Stack`, custom errors) are permitted.
 - `no-new` — `new MyStack(app, 'id', props)` is the canonical way to register stacks and constructs; the side-effecting `new` is intentional.
 - `sonarjs/constructor-for-side-effects` — child constructs register themselves on their parent via `super(scope, id)` in the constructor; the returned instance is often unused.
 - `functional/no-this-expressions` — construct constructors reference `this` to expose typed children to consumers.

--- a/test/restricted-syntax.test.js
+++ b/test/restricted-syntax.test.js
@@ -70,7 +70,7 @@ suite('restricted syntax rules', function () {
 
     test('createNoClassDeclarationRestriction with CDK pattern permits CDK base classes', function () {
         const cdkRestriction = createNoClassDeclarationRestriction({
-            allowedSuperClassNamePattern: '/(Error|Construct|Stack|Resource)$/',
+            allowedSuperClassNamePattern: '/(Error|Construct|Stack|Stage|App|Resource)$/',
             message: 'CDK class restriction'
         });
 
@@ -80,6 +80,8 @@ suite('restricted syntax rules', function () {
                 'class MyConstruct extends Construct {}',
                 'class MyStack extends Stack {}',
                 'class MyNestedStack extends NestedStack {}',
+                'class MyStage extends Stage {}',
+                'class MyApp extends App {}',
                 'class MyResource extends Resource {}',
                 'class MyBucket extends BaseResource {}'
             ],


### PR DESCRIPTION
## What

Add `Stage` and `App` to the `allowedSuperClassNamePattern` of the
`no-class-declaration` restriction in the `@enormora/eslint-config-aws-cdk`
preset, widening the allowlist from `/(Error|Construct|Stack|Resource)$/`
to `/(Error|Construct|Stack|Stage|App|Resource)$/`.

## Why

`Stage` and `App` are core `aws-cdk-lib` constructs (`App` extends `Stage`).
Subclassing `Stage` is the standard way to build a custom synthesis boundary —
e.g. an in-memory `App` replacement that overrides `synth()` for zero-I/O CDK
template tests. The current allowlist forces consumers into a per-file ESLint
override for these legitimate subclasses.

## Changes

- `configs/presets/aws-cdk/aws-cdk.js` — widen the allowlist pattern.
- `test/restricted-syntax.test.js` — extend the existing
  `createNoClassDeclarationRestriction with CDK pattern` case with
  `class MyStage extends Stage {}` and `class MyApp extends App {}` alongside
  the other allowed-class cases.
- `configs/presets/aws-cdk/aws-cdk.md` — list `Stage` and `App` in the prose
  description of the allowlist so the docs stay accurate.

## Verification

Full lint + test suite green locally (`just lint`, `just test` — 129 passing).
