### PR TITLE
Inject dprint formatters via `settings` and apply per-language configs to code fences

### DIFF
--- a/configs/presets/astro-ts/astro-ts.md
+++ b/configs/presets/astro-ts/astro-ts.md
@@ -17,19 +17,19 @@ The preset package includes the `eslint-plugin-jsx-a11y` dependency required by 
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base, TypeScript and Astro config to the configuration array:
 
 ```javascript
-import { astroConfig } from "@enormora/eslint-config-astro-ts";
-import { baseConfig } from "@enormora/eslint-config-base";
-import { typescriptConfig } from "@enormora/eslint-config-typescript";
+import { astroConfig } from '@enormora/eslint-config-astro-ts';
+import { baseConfig } from '@enormora/eslint-config-base';
+import { typescriptConfig } from '@enormora/eslint-config-typescript';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...typescriptConfig,
-    files: ["**/*.ts"],
-  },
-  ...astroConfig,
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...typescriptConfig,
+        files: [ '**/*.ts' ]
+    },
+    ...astroConfig
 ];
 ```

--- a/configs/presets/astro/astro.md
+++ b/configs/presets/astro/astro.md
@@ -17,14 +17,14 @@ The preset package includes the `eslint-plugin-jsx-a11y` dependency required by 
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and Astro config to the configuration array:
 
 ```javascript
-import { astroConfig } from "@enormora/eslint-config-astro";
-import { baseConfig } from "@enormora/eslint-config-base";
+import { astroConfig } from '@enormora/eslint-config-astro';
+import { baseConfig } from '@enormora/eslint-config-base';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  ...astroConfig,
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    ...astroConfig
 ];
 ```

--- a/configs/presets/ava/ava.md
+++ b/configs/presets/ava/ava.md
@@ -15,17 +15,17 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-ava
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and node config to the configuration array:
 
 ```javascript
-import { avaConfig } from "@enormora/eslint-config-ava";
-import { baseConfig } from "@enormora/eslint-config-base";
+import { avaConfig } from '@enormora/eslint-config-ava';
+import { baseConfig } from '@enormora/eslint-config-base';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...avaConfig,
-    files: ["**/*.test.js"],
-  },
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...avaConfig,
+        files: [ '**/*.test.js' ]
+    }
 ];
 ```

--- a/configs/presets/aws-cdk/aws-cdk.md
+++ b/configs/presets/aws-cdk/aws-cdk.md
@@ -22,22 +22,22 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-type
 Apply the preset to the directories that hold CDK code (typically a folder named `infrastructure/` or similar) in your `eslint.config.js`:
 
 ```javascript
-import { awsCdkConfig } from "@enormora/eslint-config-aws-cdk";
-import { baseConfig } from "@enormora/eslint-config-base";
-import { typescriptConfig } from "@enormora/eslint-config-typescript";
+import { awsCdkConfig } from '@enormora/eslint-config-aws-cdk';
+import { baseConfig } from '@enormora/eslint-config-base';
+import { typescriptConfig } from '@enormora/eslint-config-typescript';
 
 export default [
-  {
-    ignores: ["cdk.out/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...typescriptConfig,
-    files: ["**/*.ts"],
-  },
-  {
-    ...awsCdkConfig,
-    files: ["**/infrastructure/**/*.ts"],
-  },
+    {
+        ignores: [ 'cdk.out/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...typescriptConfig,
+        files: [ '**/*.ts' ]
+    },
+    {
+        ...awsCdkConfig,
+        files: [ '**/infrastructure/**/*.ts' ]
+    }
 ];
 ```

--- a/configs/presets/base-with-prettier/base-with-prettier.md
+++ b/configs/presets/base-with-prettier/base-with-prettier.md
@@ -21,11 +21,11 @@ Provide a `prettier.config.js` at your project root with the formatting options 
 
 ```javascript
 export default {
-  printWidth: 120,
-  tabWidth: 4,
-  singleQuote: true,
-  trailingComma: "none",
-  arrowParens: "always",
+    printWidth: 120,
+    tabWidth: 4,
+    singleQuote: true,
+    trailingComma: 'none',
+    arrowParens: 'always'
 };
 ```
 
@@ -33,12 +33,12 @@ Create an ESLint configuration file (e.g., `eslint.config.js`) in your project a
 array:
 
 ```javascript
-import { baseWithPrettierConfig } from "@enormora/eslint-config-base-with-prettier";
+import { baseWithPrettierConfig } from '@enormora/eslint-config-base-with-prettier';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  baseWithPrettierConfig,
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    baseWithPrettierConfig
 ];
 ```

--- a/configs/presets/base/base.js
+++ b/configs/presets/base/base.js
@@ -1,13 +1,8 @@
-/* eslint-disable import/no-unassigned-import -- side-effect imports surface the dprint formatter packages to Packtory's static dependency scanner so they end up as runtime dependencies of the published package */
-import '@dprint/json';
-import '@dprint/markdown';
-import '@dprint/toml';
-import '@dprint/typescript';
-/* eslint-enable import/no-unassigned-import -- end of Packtory-visibility imports */
 import dprintPlugin from '@ben_12/eslint-plugin-dprint';
 import simpleParser from '@ben_12/eslint-simple-parser';
 import { baseSharedConfig } from './base-shared.js';
 import { jsonDprintConfig, tomlDprintConfig, typescriptDprintConfig, yamlDprintConfig } from './dprint-config.js';
+import { dprintSettings } from './dprint-formatters.js';
 import { markdownConfig } from './markdown.js';
 
 const baseJsConfig = {
@@ -17,6 +12,7 @@ const baseJsConfig = {
         ...baseSharedConfig.plugins,
         dprint: dprintPlugin
     },
+    settings: { ...baseSharedConfig.settings, ...dprintSettings },
     rules: {
         ...baseSharedConfig.rules,
 
@@ -38,6 +34,7 @@ const dprintJsonConfig = {
     files: [ '**/*.json' ],
     languageOptions: { parser: simpleParser },
     plugins: { dprint: dprintPlugin },
+    settings: dprintSettings,
     rules: { 'dprint/json': [ 'error', { config: jsonDprintConfig } ] }
 };
 
@@ -45,6 +42,7 @@ const dprintYamlConfig = {
     files: [ '**/*.{yml,yaml}' ],
     languageOptions: { parser: simpleParser },
     plugins: { dprint: dprintPlugin },
+    settings: dprintSettings,
     rules: { 'dprint/yaml': [ 'error', { config: yamlDprintConfig } ] }
 };
 
@@ -52,6 +50,7 @@ const dprintTomlConfig = {
     files: [ '**/*.toml' ],
     languageOptions: { parser: simpleParser },
     plugins: { dprint: dprintPlugin },
+    settings: dprintSettings,
     rules: { 'dprint/toml': [ 'error', { config: tomlDprintConfig } ] }
 };
 

--- a/configs/presets/base/base.md
+++ b/configs/presets/base/base.md
@@ -41,12 +41,12 @@ files with JS-only rules (e.g. `eslint-plugin-n`) will try to run on `.md` and c
 scope them to JS/TS files explicitly:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
-import { nodeConfig } from "@enormora/eslint-config-node";
+import { baseConfig } from '@enormora/eslint-config-base';
+import { nodeConfig } from '@enormora/eslint-config-node';
 
 export default [
-  ...baseConfig,
-  { ...nodeConfig, files: ["**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"] },
+    ...baseConfig,
+    { ...nodeConfig, files: [ '**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}' ] }
 ];
 ```
 
@@ -62,13 +62,13 @@ Create an ESLint configuration file (e.g., `eslint.config.js`) in your project a
 configuration array:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
+import { baseConfig } from '@enormora/eslint-config-base';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig
 ];
 ```
 
@@ -92,9 +92,9 @@ therefore:
 
 ```json
 {
-  "scripts": {
-    "lint": "eslint . .github"
-  }
+    "scripts": {
+        "lint": "eslint . .github"
+    }
 }
 ```
 
@@ -107,8 +107,8 @@ Disable a formatter entirely:
 
 ```javascript
 export default [
-  ...baseConfig,
-  { files: ["**/*.json"], rules: { "dprint/json": "off" } },
+    ...baseConfig,
+    { files: [ '**/*.json' ], rules: { 'dprint/json': 'off' } }
 ];
 ```
 
@@ -116,9 +116,9 @@ Scope a formatter to a different path (turn the default off, then re-enable on y
 
 ```javascript
 export default [
-  ...baseConfig,
-  { files: ["**/*.json"], rules: { "dprint/json": "off" } },
-  { files: ["src/**/*.json"], rules: { "dprint/json": "error" } },
+    ...baseConfig,
+    { files: [ '**/*.json' ], rules: { 'dprint/json': 'off' } },
+    { files: [ 'src/**/*.json' ], rules: { 'dprint/json': 'error' } }
 ];
 ```
 
@@ -126,8 +126,8 @@ Ignore specific paths from formatting:
 
 ```javascript
 export default [
-  ...baseConfig,
-  { ignores: ["vendor/**/*.json", "fixtures/**/*.md"] },
+    ...baseConfig,
+    { ignores: [ 'vendor/**/*.json', 'fixtures/**/*.md' ] }
 ];
 ```
 
@@ -138,18 +138,18 @@ block — the same pattern as for any other ESLint rule:
 
 ```javascript
 export default [
-  ...baseConfig,
-  {
-    files: ["**/*.md"],
-    rules: {
-      "markdown/no-html": "off",
-      "markdown/fenced-code-language": ["error", { required: ["js", "ts"] }],
-      // Turn the opt-in network-based dead-link check on locally:
-      "markdown-links/no-dead-urls": "error",
-      // Opt into a stricter formatting rule from markdown-preferences:
-      "markdown-preferences/heading-casing": ["error", { style: "Sentence case" }],
-    },
-  },
+    ...baseConfig,
+    {
+        files: [ '**/*.md' ],
+        rules: {
+            'markdown/no-html': 'off',
+            'markdown/fenced-code-language': [ 'error', { required: [ 'js', 'ts' ] } ],
+            // Turn the opt-in network-based dead-link check on locally:
+            'markdown-links/no-dead-urls': 'error',
+            // Opt into a stricter formatting rule from markdown-preferences:
+            'markdown-preferences/heading-casing': [ 'error', { style: 'Sentence case' } ]
+        }
+    }
 ];
 ```
 
@@ -159,15 +159,15 @@ To override an individual dprint option (e.g. line width, quote style), add a la
 with your own `config`:
 
 ```javascript
-import { baseConfig, typescriptDprintConfig } from "@enormora/eslint-config-base";
+import { baseConfig, typescriptDprintConfig } from '@enormora/eslint-config-base';
 
 export default [
-  ...baseConfig,
-  {
-    files: ["**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,vue}"],
-    rules: {
-      "dprint/typescript": ["error", { config: { ...typescriptDprintConfig, lineWidth: 100 } }],
-    },
-  },
+    ...baseConfig,
+    {
+        files: [ '**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,vue}' ],
+        rules: {
+            'dprint/typescript': [ 'error', { config: { ...typescriptDprintConfig, lineWidth: 100 } } ]
+        }
+    }
 ];
 ```

--- a/configs/presets/base/dprint-formatters.js
+++ b/configs/presets/base/dprint-formatters.js
@@ -1,0 +1,30 @@
+import { fileURLToPath } from 'node:url';
+import dprintJsonFormatter from '@dprint/json';
+import dprintMarkdownFormatter from '@dprint/markdown';
+import dprintTomlFormatter from '@dprint/toml';
+import dprintTypescriptFormatter from '@dprint/typescript';
+
+// `dprint-plugin-yaml` ships only `plugin.wasm` and `package.json` — there is no JS entry to import
+// from. Packtory's dependency scanner records `import.meta.resolve('<pkg>/plugin.wasm')` call sites
+// (since `@packtory/cli@0.0.31`), so this call is what makes the package land in the published
+// `dependencies`. The dprint plugin reads the bytes itself when it resolves a `getPath`-shaped
+// formatter, so we just hand it the path.
+const dprintYamlWasmPath = fileURLToPath(import.meta.resolve('dprint-plugin-yaml/plugin.wasm'));
+
+const dprintYamlFormatter = {
+    getPath() {
+        return dprintYamlWasmPath;
+    }
+};
+
+export const dprintSettings = {
+    '@ben_12/dprint': {
+        formatters: {
+            typescript: dprintTypescriptFormatter,
+            json: dprintJsonFormatter,
+            markdown: dprintMarkdownFormatter,
+            toml: dprintTomlFormatter,
+            yaml: dprintYamlFormatter
+        }
+    }
+};

--- a/configs/presets/base/markdown.js
+++ b/configs/presets/base/markdown.js
@@ -2,7 +2,14 @@ import dprintPlugin from '@ben_12/eslint-plugin-dprint';
 import markdownPlugin from '@eslint/markdown';
 import markdownLinksPlugin from 'eslint-plugin-markdown-links';
 import markdownPreferencesPlugin from 'eslint-plugin-markdown-preferences';
-import { markdownDprintConfig } from './dprint-config.js';
+import {
+    jsonDprintConfig,
+    markdownDprintConfig,
+    tomlDprintConfig,
+    typescriptDprintConfig,
+    yamlDprintConfig
+} from './dprint-config.js';
+import { dprintSettings } from './dprint-formatters.js';
 
 // `@eslint/markdown` declares `language: 'markdown/commonmark'` for .md files, which makes ESLint
 // parse them into an mdast tree (root node `type: 'root'`). The stock `dprint/markdown` rule listens
@@ -36,8 +43,20 @@ export const markdownConfig = {
     // 10's reporter ("Custom getLoc() method must be implemented in the subclass"). Revisit once
     // @eslint/markdown ships a fix.
     language: 'markdown/commonmark',
+    settings: dprintSettings,
     rules: {
-        'dprint-markdown/markdown': [ 'error', { config: markdownDprintConfig } ],
+        'dprint-markdown/markdown': [
+            'error',
+            {
+                config: markdownDprintConfig,
+                hostConfigs: {
+                    typescript: typescriptDprintConfig,
+                    json: jsonDprintConfig,
+                    toml: tomlDprintConfig,
+                    yaml: yamlDprintConfig
+                }
+            }
+        ],
 
         'markdown/fenced-code-language': 'error',
         'markdown/fenced-code-meta': 'off',

--- a/configs/presets/browser/browser.md
+++ b/configs/presets/browser/browser.md
@@ -15,17 +15,17 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-brow
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and browser config to the configuration array:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
-import { browserConfig } from "@enormora/eslint-config-browser";
+import { baseConfig } from '@enormora/eslint-config-base';
+import { browserConfig } from '@enormora/eslint-config-browser';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...browserConfig,
-    files: ["src/browser/**/*.js"],
-  },
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...browserConfig,
+        files: [ 'src/browser/**/*.js' ]
+    }
 ];
 ```

--- a/configs/presets/mocha/mocha.md
+++ b/configs/presets/mocha/mocha.md
@@ -15,17 +15,17 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-moch
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and mocha config to the configuration array:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
-import { mochaConfig } from "@enormora/eslint-config-mocha";
+import { baseConfig } from '@enormora/eslint-config-base';
+import { mochaConfig } from '@enormora/eslint-config-mocha';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...mochaConfig,
-    files: ["**/*.test.js"],
-  },
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...mochaConfig,
+        files: [ '**/*.test.js' ]
+    }
 ];
 ```

--- a/configs/presets/node/node.md
+++ b/configs/presets/node/node.md
@@ -15,18 +15,18 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-node
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and node config to the configuration array:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
-import { nodeConfig } from "@enormora/eslint-config-node";
+import { baseConfig } from '@enormora/eslint-config-base';
+import { nodeConfig } from '@enormora/eslint-config-node';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...nodeConfig,
-    files: ["src/server/**/*.js"],
-  },
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...nodeConfig,
+        files: [ 'src/server/**/*.js' ]
+    }
 ];
 ```
 

--- a/configs/presets/react-jsx/react-jsx.md
+++ b/configs/presets/react-jsx/react-jsx.md
@@ -15,17 +15,17 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-reac
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and react config to the configuration array:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
-import { reactJsxConfig } from "@enormora/eslint-config-react-jsx";
+import { baseConfig } from '@enormora/eslint-config-base';
+import { reactJsxConfig } from '@enormora/eslint-config-react-jsx';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...reactJsxConfig,
-    files: ["src/components/**/*.jsx"],
-  },
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...reactJsxConfig,
+        files: [ 'src/components/**/*.jsx' ]
+    }
 ];
 ```

--- a/configs/presets/react-tsx/react-tsx.md
+++ b/configs/presets/react-tsx/react-tsx.md
@@ -15,17 +15,17 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-type
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and react config to the configuration array:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
-import { reactTsxConfig } from "@enormora/eslint-config-react-tsx";
+import { baseConfig } from '@enormora/eslint-config-base';
+import { reactTsxConfig } from '@enormora/eslint-config-react-tsx';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...reactTsxConfig,
-    files: ["src/components/**/*.tsx"],
-  },
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...reactTsxConfig,
+        files: [ 'src/components/**/*.tsx' ]
+    }
 ];
 ```

--- a/configs/presets/react/react.md
+++ b/configs/presets/react/react.md
@@ -15,17 +15,17 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-reac
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and react config to the configuration array:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
-import { reactConfig } from "@enormora/eslint-config-react";
+import { baseConfig } from '@enormora/eslint-config-base';
+import { reactConfig } from '@enormora/eslint-config-react';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...reactConfig,
-    files: ["src/components/**/*.js"],
-  },
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...reactConfig,
+        files: [ 'src/components/**/*.js' ]
+    }
 ];
 ```

--- a/configs/presets/typescript/typescript.md
+++ b/configs/presets/typescript/typescript.md
@@ -15,17 +15,17 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-type
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and node config to the configuration array:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
-import { typescriptConfig } from "@enormora/eslint-config-typescript";
+import { baseConfig } from '@enormora/eslint-config-base';
+import { typescriptConfig } from '@enormora/eslint-config-typescript';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...typescriptConfig,
-    files: ["**/*.ts"],
-  },
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...typescriptConfig,
+        files: [ '**/*.ts' ]
+    }
 ];
 ```

--- a/configs/presets/vitest/vitest.md
+++ b/configs/presets/vitest/vitest.md
@@ -15,17 +15,17 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-vite
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and mocha config to the configuration array:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
-import { vitestConfig } from "@enormora/eslint-config-vitest";
+import { baseConfig } from '@enormora/eslint-config-base';
+import { vitestConfig } from '@enormora/eslint-config-vitest';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...vitestConfig,
-    files: ["**/*.test.js"],
-  },
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...vitestConfig,
+        files: [ '**/*.test.js' ]
+    }
 ];
 ```

--- a/configs/presets/vue-ts/vue-ts.md
+++ b/configs/presets/vue-ts/vue-ts.md
@@ -15,17 +15,17 @@ npm install --save-dev @enormora/eslint-config-base @enormora/eslint-config-type
 Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the base and react config to the configuration array:
 
 ```javascript
-import { baseConfig } from "@enormora/eslint-config-base";
-import { vueConfig } from "@enormora/eslint-config-vue-ts";
+import { baseConfig } from '@enormora/eslint-config-base';
+import { vueConfig } from '@enormora/eslint-config-vue-ts';
 
 export default [
-  {
-    ignores: ["dist/**/*"],
-  },
-  ...baseConfig,
-  {
-    ...vueConfig,
-    files: ["src/**/*.vue"],
-  },
+    {
+        ignores: [ 'dist/**/*' ]
+    },
+    ...baseConfig,
+    {
+        ...vueConfig,
+        files: [ 'src/**/*.vue' ]
+    }
 ];
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,9 @@
                 "prettier": "3.8.3",
                 "rust-just": "1.51.0",
                 "typescript": "6.0.3"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@andrewbranch/untar.js": {
@@ -107,16 +110,6 @@
             },
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "node_modules/@arethetypeswrong/core/node_modules/validate-npm-package-name": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-            "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@astrojs/compiler": {
@@ -1559,9 +1552,9 @@
             }
         },
         "node_modules/@npmcli/agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-5.0.0.tgz",
-            "integrity": "sha512-l0D4O+PYIyanxTyOFzFuvOOvWA0sihzvmA/RFyfoqfdnSU0SjVsHiAk1EvuZdKLB/R3hrUafhJGi6RrQV0RZBA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-5.0.1.tgz",
+            "integrity": "sha512-PsOUeQRpNOGH+Iks/YPY8AXtttvGVqNqKIo/Cp2LhI0jpeqW32JP14yYRym+OsTg+roH4Avw281YwHMp8X8L2Q==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1576,9 +1569,9 @@
             }
         },
         "node_modules/@npmcli/agent/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -1629,9 +1622,9 @@
             }
         },
         "node_modules/@npmcli/git/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -1687,9 +1680,9 @@
             }
         },
         "node_modules/@npmcli/package-json/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -1912,9 +1905,9 @@
             }
         },
         "node_modules/@sigstore/sign/node_modules/@npmcli/agent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-            "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+            "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2012,9 +2005,9 @@
             }
         },
         "node_modules/@sigstore/sign/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -2022,9 +2015,9 @@
             }
         },
         "node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
-            "version": "15.0.5",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
-            "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+            "version": "15.0.6",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+            "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3264,9 +3257,9 @@
             }
         },
         "node_modules/bare-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+            "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3531,9 +3524,9 @@
             }
         },
         "node_modules/cacache/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -6494,9 +6487,9 @@
             }
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -7580,9 +7573,9 @@
             }
         },
         "node_modules/libnpmpublish/node_modules/@npmcli/agent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-            "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+            "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -7693,9 +7686,9 @@
             }
         },
         "node_modules/libnpmpublish/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -7703,9 +7696,9 @@
             }
         },
         "node_modules/libnpmpublish/node_modules/make-fetch-happen": {
-            "version": "15.0.5",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
-            "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+            "version": "15.0.6",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+            "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -7950,9 +7943,9 @@
             }
         },
         "node_modules/make-fetch-happen": {
-            "version": "16.0.0",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-16.0.0.tgz",
-            "integrity": "sha512-IG4HwAqOF4cu117J5H12dTTUcmKwb/lX8BtxgvxLNScjev3fRCqjd9r0kw7L1bK+KGgGU7XjA5+oDuhd+kl6Jg==",
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-16.0.1.tgz",
+            "integrity": "sha512-uUv1yxHzaKVVEPfcFeGSNov/Cehjv08ovlY8ImTljgL7Q+SiA0dAYLQ6SYVa2kkKqNj4Y3aZEI7xv2teadie0A==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -9576,6 +9569,16 @@
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
+        "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-8.0.0.tgz",
+            "integrity": "sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
         "node_modules/npm-pick-manifest": {
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
@@ -9606,9 +9609,9 @@
             }
         },
         "node_modules/npm-pick-manifest/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -10095,9 +10098,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -11290,9 +11293,9 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.25.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
-            "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+            "version": "2.26.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
+            "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11817,9 +11820,9 @@
             }
         },
         "node_modules/tuf-js/node_modules/@npmcli/agent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-            "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+            "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -11917,9 +11920,9 @@
             }
         },
         "node_modules/tuf-js/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -11927,9 +11930,9 @@
             }
         },
         "node_modules/tuf-js/node_modules/make-fetch-happen": {
-            "version": "15.0.5",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
-            "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+            "version": "15.0.6",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+            "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -12500,13 +12503,13 @@
             }
         },
         "node_modules/validate-npm-package-name": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-8.0.0.tgz",
-            "integrity": "sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+            "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/vscode-languageserver-textdocument": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     ],
     "scripts": {},
     "license": "MIT",
+    "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+    },
     "dependencies": {
         "@ben_12/eslint-plugin-dprint": "1.21.0",
         "@ben_12/eslint-simple-parser": "0.1.0",


### PR DESCRIPTION
Switches from the side-effect-import workaround to the new `settings.formatters` channel in `@ben_12/eslint-plugin-dprint` 1.21.0, with `dprint-plugin-yaml` surfaced to packtory via `import.meta.resolve('dprint-plugin-yaml/plugin.wasm')` (requires `@packtory/cli` 0.0.31). Code fences in `.md` files now reformat with the project's `typescriptDprintConfig` / `jsonDprintConfig` / `tomlDprintConfig` / `yamlDprintConfig` via the rule's new `hostConfigs` option — the preset `.md` reformat is the direct consequence. `engines.node` is pinned to ESLint 10's supported range because `import.meta.resolve` needs Node `>= 20.6` and `eslint-plugin-n` derives feature support from this field.
