### PR TITLE
Disable functional immutability rules in the AWS CDK preset

### DIFF
--- a/configs/presets/aws-cdk/aws-cdk.js
+++ b/configs/presets/aws-cdk/aws-cdk.js
@@ -10,6 +10,8 @@ export const awsCdkConfig = {
         'restricted-syntax/no-class-declaration': [ 'error', cdkClassDeclarationRestriction ],
         'no-new': 'off',
         'sonarjs/constructor-for-side-effects': 'off',
-        'functional/no-this-expressions': 'off'
+        'functional/no-this-expressions': 'off',
+        'functional/prefer-immutable-types': 'off',
+        'functional/type-declaration-immutability': 'off'
     }
 };

--- a/configs/presets/aws-cdk/aws-cdk.md
+++ b/configs/presets/aws-cdk/aws-cdk.md
@@ -10,6 +10,7 @@ Config preset for AWS CDK projects. Disables a small set of rules that conflict 
 - `no-new` — `new MyStack(app, 'id', props)` is the canonical way to register stacks and constructs; the side-effecting `new` is intentional.
 - `sonarjs/constructor-for-side-effects` — child constructs register themselves on their parent via `super(scope, id)` in the constructor; the returned instance is often unused.
 - `functional/no-this-expressions` — construct constructors reference `this` to expose typed children to consumers.
+- `functional/prefer-immutable-types` and `functional/type-declaration-immutability` — CDK constructs are mutable class instances, so `Readonly<Construct>` drops their methods and private fields and no longer type-checks as the construct; the rules cannot be satisfied for parameters or type aliases built on construct types.
 
 ## Install & Setup
 

--- a/test/aws-cdk.test.js
+++ b/test/aws-cdk.test.js
@@ -1,9 +1,19 @@
 import { suite, test } from 'mocha';
 import { awsCdkConfig } from '../configs/presets/aws-cdk/aws-cdk.js';
-import { checkConfigToHaveNoValidationIssues } from './rules-configuration.js';
+import { checkAdditionalRulesConfigured, checkConfigToHaveNoValidationIssues } from './rules-configuration.js';
 
 suite('aws-cdk preset', function () {
     test('aws-cdk preset config has no validation errors', function () {
         checkConfigToHaveNoValidationIssues(awsCdkConfig);
+    });
+
+    test('aws-cdk preset config disables the immutability rules that CDK constructs cannot satisfy', function () {
+        checkAdditionalRulesConfigured({
+            ruleConfigSet: awsCdkConfig.rules,
+            additionalRules: {
+                'functional/prefer-immutable-types': 'off',
+                'functional/type-declaration-immutability': 'off'
+            }
+        });
     });
 });


### PR DESCRIPTION
## What

Disable two `eslint-plugin-functional` immutability rules in the
`@enormora/eslint-config-aws-cdk` preset:

    'functional/prefer-immutable-types': 'off',
    'functional/type-declaration-immutability': 'off'

## Why

AWS CDK is a builder-pattern, mutation-based API. Constructs (`Stack`,
`Construct`, `IFunction`, `LogGroup`, etc.) are class instances with mutable
public members and methods. `functional/prefer-immutable-types`
(`ReadonlyShallow`) flags every parameter typed as a CDK construct, and there
is no way to satisfy it: `Readonly<Stack>` is a mapped type that drops the
class's methods and private fields, so it no longer type-checks as the original
construct. `functional/type-declaration-immutability` has the same problem for
type aliases built on construct types.

This is the same "functional purity does not fit CDK" category the preset
already concedes: `awsCdkConfig` disables `functional/no-this-expressions`,
`no-new`, and `sonarjs/constructor-for-side-effects`, and relaxes
`restricted-syntax/no-class-declaration` to allow CDK base classes. The two
immutability rules belong in that same set. Without this, every consumer of the
preset has to re-disable these two rules in their own infrastructure file scope,
which defeats the purpose of a shared CDK preset.

## Changes

- `configs/presets/aws-cdk/aws-cdk.js` — add the two `off` rule entries.
- `test/aws-cdk.test.js` — assert both rules are disabled via the existing
  `checkAdditionalRulesConfigured` helper (same pattern as `mocha.test.js`).
- `configs/presets/aws-cdk/aws-cdk.md` — document the two rules in the
  "What it disables and why" list so the docs stay complete.

## Verification

Full lint + test suite green locally (`just lint`, `just test` — 130 passing).
