### PR TITLE
Add scheduled auto-publish with OIDC trusted publishing

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,8 +42,6 @@ jobs:
             - name: Run tests
               run: npx just test
             - name: Packtory dry-run
-              env:
-                  NPM_TOKEN: dry-run
               run: npx just packtory-dry-run
 
     workflow-security:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,97 @@
+---
+name: Publish
+
+on:
+    workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+    group: publish-main
+
+jobs:
+    evaluate-gate:
+        runs-on: ubuntu-24.04
+        name: Evaluate GitHub release gate
+        permissions:
+            contents: read # required for actions/checkout to read the workflow source
+            issues: read # required by the release gate to inspect open issues for activity
+            pull-requests: read # required by the release gate to inspect open PRs for activity
+        outputs:
+            should_publish: ${{ steps.release-gate.outputs.should_publish }}
+            reason: ${{ steps.release-gate.outputs.reason }}
+            main_head_sha: ${{ steps.release-gate.outputs.main_head_sha }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  ref: main
+                  persist-credentials: false
+            - name: Use Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version: 26.x
+            - name: Install dependencies from the lockfile
+              run: npm clean-install --ignore-scripts
+            - name: Evaluate GitHub release gate
+              id: release-gate
+              run: npx github-release-gate
+              env:
+                  CI_WORKFLOW_FILE: continuous-integration.yml
+                  DEFAULT_BRANCH: main
+                  DEPENDENCY_ONLY_MIN_AGE_DAYS: "7"
+                  GITHUB_TOKEN: ${{ github.token }}
+                  MAX_LATENCY_HOURS: "24"
+                  QUIET_PERIOD_MINUTES: "45"
+            - name: Log gate decision when publish is skipped
+              if: steps.release-gate.outputs.should_publish != 'true'
+              env:
+                  GATE_REASON: ${{ steps.release-gate.outputs.reason }}
+              run: echo "Skipping publish because ${GATE_REASON}."
+
+    publish:
+        needs: evaluate-gate
+        if: needs.evaluate-gate.outputs.should_publish == 'true'
+        runs-on: ubuntu-24.04
+        name: Publish packages
+        permissions:
+            contents: read # required for actions/checkout to read the workflow source
+            id-token: write # required by npm trusted publishing to mint the OIDC token
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  ref: ${{ needs.evaluate-gate.outputs.main_head_sha }}
+                  persist-credentials: false
+            - name: Use Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version: 26.x
+            - name: Install dependencies from the lockfile
+              run: npm clean-install --ignore-scripts
+            - name: Verify registry signatures for installed dependencies
+              run: npm audit signatures
+            - name: Verify `@packtory/cli` ships with a provenance attestation
+              run: |
+                  version=$(jq -r '.devDependencies["@packtory/cli"]' package.json)
+                  spec="@packtory/cli@${version}"
+                  attestation=$(npm view "${spec}" --json | jq -r '.dist.attestations // empty')
+                  if [ -z "${attestation}" ]; then
+                    echo "::error::${spec} is missing a provenance attestation; refusing to publish"
+                    exit 1
+                  fi
+                  echo "Verified ${spec} has a registered provenance attestation."
+            - name: Publish packages
+              id: publish-packages
+              continue-on-error: true
+              run: npx packtory publish --no-dry-run
+            # The `sigstore` wrapper used by `libnpmpublish` hardcodes
+            # `fetchOnConflict: false`, so a retried Rekor POST after a
+            # transient blip surfaces as
+            # `error creating tlog entry - (409) an equivalent entry already exists`
+            # even though the original submission landed. Re-running publish
+            # mints a fresh OIDC cert, so the next signature differs and
+            # Rekor accepts it.
+            - name: Re-publish after a transient sigstore failure
+              if: steps.publish-packages.outcome == 'failure'
+              run: |
+                  sleep 10
+                  npx packtory publish --no-dry-run

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -1,0 +1,36 @@
+---
+name: Schedule publish
+
+on:
+    schedule:
+        # GitHub Actions throttles scheduled workflows hard at the top of the hour.
+        # Spreading entries across off-peak minutes gives the cron a better shot at firing
+        # as a fallback for the self-rechain below.
+        - cron: "17 * * * *"
+        - cron: "47 * * * *"
+    workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+    group: publish-scheduler
+
+jobs:
+    dispatch:
+        runs-on: ubuntu-24.04
+        name: Dispatch publish workflow
+        permissions:
+            actions: write # required to dispatch the publish workflow via gh CLI
+            contents: read # required by gh CLI to look up workflow metadata
+        steps:
+            - name: Dispatch publish workflow
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: gh workflow run publish.yml --ref main
+            - name: Wait then redispatch the scheduler as a cron-drift fallback
+              if: always()
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  sleep 1800
+                  gh workflow run scheduler.yml --ref main

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
             "devDependencies": {
                 "@eslint/js": "10.0.1",
                 "@packtory/cli": "0.0.31",
+                "@packtory/github-release-gate": "0.0.4",
                 "eslint": "10.4.1",
                 "mocha": "11.7.6",
                 "prettier": "3.8.3",
@@ -1738,6 +1739,144 @@
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
+        "node_modules/@octokit/auth-token": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+            "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/auth-token": "^6.0.0",
+                "@octokit/graphql": "^9.0.3",
+                "@octokit/request": "^10.0.6",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "before-after-hook": "^4.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+            "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+            "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/request": "^10.0.6",
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+            "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+            "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "10.0.10",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+            "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/endpoint": "^11.0.3",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "content-type": "^2.0.0",
+                "json-with-bigint": "^3.5.3",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+            "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+            "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^27.0.0"
+            }
+        },
         "node_modules/@package-json/types": {
             "version": "0.0.12",
             "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
@@ -1760,6 +1899,26 @@
             },
             "bin": {
                 "packtory": "packages/command-line-interface/command-line-interface.entry-point.js"
+            },
+            "engines": {
+                "node": "^24 || ^26"
+            }
+        },
+        "node_modules/@packtory/github-release-gate": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@packtory/github-release-gate/-/github-release-gate-0.0.4.tgz",
+            "integrity": "sha512-whrPwT53VOpDRAh3Lfd0YSONT8v+LuSjZ+KnNKx6TJzFkNfselWmNWoCqKFP3VhDAtuk37DD70bRmo6Y7WA6MQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/core": "7.0.6",
+                "@octokit/plugin-paginate-rest": "14.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "17.0.0",
+                "packtory": "0.0.31",
+                "remeda": "2.37.0"
+            },
+            "bin": {
+                "github-release-gate": "packages/github-release-gate/github-release-gate.entry-point.js"
             },
             "engines": {
                 "node": "^24 || ^26"
@@ -3333,6 +3492,13 @@
                 "node": ">=18.18.0"
             }
         },
+        "node_modules/before-after-hook": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3939,6 +4105,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/convert-source-map": {
@@ -7411,6 +7591,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-with-bigint": {
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+            "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
             "dev": true,
             "license": "MIT"
         },
@@ -12252,6 +12439,13 @@
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
             "license": "MIT"
+        },
+        "node_modules/universal-user-agent": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/unix-permissions": {
             "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "devDependencies": {
         "@eslint/js": "10.0.1",
         "@packtory/cli": "0.0.31",
+        "@packtory/github-release-gate": "0.0.4",
         "eslint": "10.4.1",
         "mocha": "11.7.6",
         "prettier": "3.8.3",

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -21,9 +21,6 @@ const publishingPeerDependencies = {
     typescript: '>=4.8.4 <6.1.0'
 };
 
-// eslint-disable-next-line node/no-process-env -- needed
-const npmToken = process.env.NPM_TOKEN;
-
 /** @returns {Promise<import('@packtory/cli').PacktoryConfig>} */
 export async function buildConfig() {
     const packageJsonContent = await fs.readFile(path.join(projectFolder, './package.json'), { encoding: 'utf8' });
@@ -36,13 +33,12 @@ export async function buildConfig() {
         }
     };
 
-    if (npmToken === undefined) {
-        throw new Error('Missing NPM_TOKEN environment variable');
-    }
-
     return {
         registrySettings: {
-            auth: { type: 'bearer-token', token: npmToken }
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'auto' },
+                metadata: 'auto'
+            }
         },
         checks: {
             noDuplicatedFiles: {
@@ -54,7 +50,10 @@ export async function buildConfig() {
             sourcesFolder,
             mainPackageJson: packtoryMainPackageJson,
             includeSourceMapFiles: true,
-            publishSettings: { access: 'public' },
+            publishSettings: {
+                access: 'public',
+                provenance: { type: 'auto' }
+            },
             additionalFiles: [
                 {
                     sourceFilePath: path.join(projectFolder, 'LICENSE'),


### PR DESCRIPTION
A new `scheduler.yml` fires twice an hour (with a 30-minute self-rechain to absorb GitHub Actions cron drift) and dispatches `publish.yml`, which gates on `@packtory/github-release-gate` (45 min quiet period, 24 h max latency, 7 d minimum age for dependency-only updates) before running `packtory publish --no-dry-run`.

Publishing now uses npm trusted publishing (OIDC) with build provenance: `packtory.config.js` switches from `bearer-token`/`NPM_TOKEN` to `npm-oidc` and sets `publishSettings.provenance: { type: 'auto' }`. The publish job runs `npm clean-install --ignore-scripts` to neutralize hostile install hooks, verifies installed-dependency signatures via `npm audit signatures`, and asserts that `@packtory/cli` itself ships with a provenance attestation before publishing. A second publish attempt covers the documented `sigstore`/Rekor `409` race.

The first run requires a trusted publisher to be configured on `npmjs.com` for each `@enormora/eslint-config-*` package (workflow `publish.yml`, ref `main`).