### PR TITLE
Accept named class/interface parameters in `functional/prefer-immutable-types`

### DIFF
--- a/configs/presets/typescript/typescript.js
+++ b/configs/presets/typescript/typescript.js
@@ -13,6 +13,10 @@ export const noTsEnumDeclarationRestriction = {
     message: 'Use a string union type instead'
 };
 
+const namedReferenceIgnorePattern =
+    String.raw`^(?!(?:Array|ReadonlyArray|Map|ReadonlyMap|Set|ReadonlySet|Record|Readonly)\b)` +
+    String.raw`[A-Z][\w$]*(?:\.[A-Z][\w$]*)*(?:<.*>)?$`;
+
 const functionLikeNodes = [
     'FunctionDeclaration',
     'FunctionExpression',
@@ -388,6 +392,11 @@ export const typescriptConfig = {
                 enforcement: 'ReadonlyShallow',
                 ignoreClasses: false,
                 ignoreInferredTypes: true,
+                // Mimics the deprecated functional/prefer-readonly-type: skip
+                // named class/interface/type-alias references whose upstream
+                // members are not declared readonly, so structural shallow
+                // checks cannot be satisfied by any annotation.
+                ignoreTypePattern: [ namedReferenceIgnorePattern ],
                 fixer: {
                     ReadonlyShallow: [
                         {

--- a/test/fixtures/base-typescript/named-class-type-parameters.ts
+++ b/test/fixtures/base-typescript/named-class-type-parameters.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-extraneous-class, restricted-syntax/no-class-declaration, @typescript-eslint/no-unused-vars, restricted-syntax/no-empty-function-body, @typescript-eslint/explicit-function-return-type */
+
+// Named class/interface references stand in for third-party types such as
+// `sinon.SinonSpy`, `aws-cdk-lib.App`, `aws-cdk-lib.Stage`, or `constructs.Construct`.
+// Their public members are not declared `readonly` upstream, so a purely
+// structural `ReadonlyShallow` check rejects them. The rule must mimic the
+// behavior of the deprecated `functional/prefer-readonly-type` here and let
+// named class/interface references pass while still flagging inline mutable
+// types.
+
+declare class ThirdPartySpy<TArgs extends readonly unknown[], TReturn> {
+    public callCount: number;
+    public calledWith(...args: TArgs): boolean;
+    public returnValue(value: TReturn): void;
+}
+
+declare class ThirdPartyApp {
+    public name: string;
+    public synth(): void;
+}
+
+declare class ThirdPartyConstruct {
+    public node: ThirdPartyApp;
+    public addChild(child: ThirdPartyConstruct): void;
+}
+
+interface ThirdPartyHandle {
+    label: string;
+    invoke(): void;
+}
+
+// Valid: named class/interface references in parameter position must be accepted.
+export declare function takeSpy(value: ThirdPartySpy<readonly [number], string>): void;
+export declare function takeApp(value: ThirdPartyApp): void;
+export declare function takeConstruct(value: ThirdPartyConstruct): void;
+export declare function takeHandle(value: ThirdPartyHandle): void;
+export declare function takeGenericContainer(value: ThirdPartySpy<readonly [string], number>): void;
+
+// Invalid: inline mutable structural types must still be flagged.
+export declare function takeArray(value: string[]): void;
+export declare function takeTuple(value: [number, string]): void;
+export declare function takeObjectLiteral(value: { name: string; count: number }): void;
+export declare function takeMap(value: Map<string, number>): void;
+export declare function takeSet(value: Set<string>): void;

--- a/test/integration/base-typescript.test.js
+++ b/test/integration/base-typescript.test.js
@@ -144,4 +144,31 @@ suite('base+typescript integration', function () {
             });
         assert.deepStrictEqual(immutabilityMessages, []);
     });
+
+    test('base+typescript named class/interface parameters pass while inline mutable parameters are flagged', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'named-class-type-parameters.ts');
+        const flaggedLines = new Set(
+            messages
+                .filter((message) => {
+                    return message.ruleId === 'functional/prefer-immutable-types';
+                })
+                .map((message) => {
+                    return message.line;
+                })
+        );
+        const acceptedNamedTypeLines = new Set([ 33, 34, 35, 36, 37 ]);
+        const expectedInlineMutableLines = new Set([ 40, 41, 42, 43, 44 ]);
+        const unexpectedNamedTypeReports = Array.from(acceptedNamedTypeLines).filter((line) => {
+            return flaggedLines.has(line);
+        });
+        const missingInlineMutableReports = Array.from(expectedInlineMutableLines).filter((line) => {
+            return !flaggedLines.has(line);
+        });
+        assert.deepStrictEqual(unexpectedNamedTypeReports, [], 'named class/interface parameters must not be flagged');
+        assert.deepStrictEqual(
+            missingInlineMutableReports,
+            [],
+            'inline mutable parameter types must still be flagged'
+        );
+    });
 });


### PR DESCRIPTION
The structural `ReadonlyShallow` check rejects parameters typed as third-party class instances (for example `SinonSpy`, `App`, `Stage`, `Construct`) because their upstream declarations do not mark every member `readonly`, and no consumer-side annotation can satisfy the rule.

Add an `ignoreTypePattern` entry that matches PascalCase named references (optionally generic or dotted) while keeping inline mutable containers — `Array`, `Map`, `Set`, `Record`, their `Readonly*` variants, tuple types, and object-literal types — under the rule. This restores the behavior of the deprecated `functional/prefer-readonly-type`.

A regression fixture and integration test cover both the accepted named-reference parameters and the still-flagged inline mutable parameters.

Known gap: `Record<K, V>` in parameter position is still silently accepted. Root cause is an upstream short-circuit in `is-immutable-type@5.0.2` (`createIndexSignatureTaskStates`) that ignores `indexInfo.isReadonly` when the caller caps `maxImmutability` at `ReadonlyShallow`. To be fixed upstream.
