### PR TITLE
Supply repo context to `gh workflow run` in the publish scheduler

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -26,11 +26,13 @@ jobs:
             - name: Dispatch publish workflow
               env:
                   GH_TOKEN: ${{ github.token }}
+                  GH_REPO: ${{ github.repository }}
               run: gh workflow run publish.yml --ref main
             - name: Wait then redispatch the scheduler as a cron-drift fallback
               if: always()
               env:
                   GH_TOKEN: ${{ github.token }}
+                  GH_REPO: ${{ github.repository }}
               run: |
                   sleep 1800
                   gh workflow run scheduler.yml --ref main


### PR DESCRIPTION
The `Schedule publish` workflow's `dispatch` job has no `actions/checkout` step, so `gh workflow run` cannot infer the repository from a git remote and exits with `fatal: not a git repository`. Both steps in `.github/workflows/scheduler.yml` now set `GH_REPO: ${{ github.repository }}` on the step `env`, which `gh` reads natively for the target repo — no checkout step and no `${{ }}` expansion inside `run:` (which zizmor's pedantic persona flags as template injection).

Failing run for reference: https://github.com/enormora/eslint-config/actions/runs/26819043836
