### PR TITLE
Restore parity between `base` and `base-with-prettier` presets

### DIFF
--- a/configs/presets/base-with-prettier/base-with-prettier.js
+++ b/configs/presets/base-with-prettier/base-with-prettier.js
@@ -1,7 +1,10 @@
+import simpleParser from '@ben_12/eslint-simple-parser';
 import prettierPlugin from 'eslint-plugin-prettier';
 import { baseSharedConfig } from '../base/base-shared.js';
+import { markdownLintPlugins, markdownLintRules } from '../base/markdown-lint-rules.js';
 
-export const baseWithPrettierConfig = {
+const baseJsConfig = {
+    files: [ '**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,vue}' ],
     ...baseSharedConfig,
     plugins: {
         ...baseSharedConfig.plugins,
@@ -10,6 +13,49 @@ export const baseWithPrettierConfig = {
     rules: {
         ...baseSharedConfig.rules,
 
-        'prettier/prettier': 'error'
+        'prettier/prettier': 'error',
+
+        // Prettier owns TypeScript member delimiter formatting; the stylistic rule would only fight it.
+        '@stylistic/member-delimiter-style': 'off'
     }
 };
+
+const prettierJsonConfig = {
+    files: [ '**/*.json' ],
+    languageOptions: { parser: simpleParser },
+    plugins: { prettier: prettierPlugin },
+    rules: { 'prettier/prettier': 'error' }
+};
+
+const prettierYamlConfig = {
+    files: [ '**/*.{yml,yaml}' ],
+    languageOptions: { parser: simpleParser },
+    plugins: { prettier: prettierPlugin },
+    rules: { 'prettier/prettier': 'error' }
+};
+
+const markdownConfig = {
+    files: [ '**/*.md' ],
+    plugins: {
+        ...markdownLintPlugins,
+        prettier: prettierPlugin
+    },
+    // See ../base/markdown.js for why this is pinned to commonmark instead of gfm.
+    language: 'markdown/commonmark',
+    rules: {
+        'prettier/prettier': 'error',
+
+        ...markdownLintRules
+    }
+};
+
+export const baseWithPrettierConfig = [
+    baseJsConfig,
+    prettierJsonConfig,
+    markdownConfig,
+    prettierYamlConfig
+];
+
+/* eslint-disable no-barrel-files/no-barrel-files -- expose cspell helper as public API so consumers can spread or call it when customizing */
+export { withCspellWords } from '../base/cspell-config.js';
+/* eslint-enable no-barrel-files/no-barrel-files -- end of public re-exports */

--- a/configs/presets/base-with-prettier/base-with-prettier.md
+++ b/configs/presets/base-with-prettier/base-with-prettier.md
@@ -6,7 +6,10 @@ Drop-in alternative to [`@enormora/eslint-config-base`](../base/base.md) that fo
 [prettier](https://prettier.io/) instead of dprint.
 
 This preset is itself a base preset — pick this one **or** `@enormora/eslint-config-base`, never both. It contains the
-same set of lint rules as the regular base preset; the only difference is the formatter integration.
+same set of lint rules as the regular base preset, including the semantic markdown linting stack
+(`@eslint/markdown`, `eslint-plugin-markdown-links`, `eslint-plugin-markdown-preferences`). The only differences are
+the formatter integration and that TOML is not covered (prettier has no native TOML support; see
+[Limitations](#limitations) below).
 
 ## Install & Setup
 
@@ -29,8 +32,8 @@ export default {
 };
 ```
 
-Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and add the preset to the configuration
-array:
+Create an ESLint configuration file (e.g., `eslint.config.js`) in your project and spread the preset into the
+configuration array:
 
 ```javascript
 import { baseWithPrettierConfig } from '@enormora/eslint-config-base-with-prettier';
@@ -39,6 +42,80 @@ export default [
     {
         ignores: [ 'dist/**/*' ]
     },
-    baseWithPrettierConfig
+    ...baseWithPrettierConfig
 ];
 ```
+
+`baseWithPrettierConfig` is an array of flat config blocks. The first block targets the JS/TS/Vue file set and carries
+the lint rules; the remaining blocks each scope `prettier/prettier` to one file family, with the markdown block
+additionally enabling the semantic markdown linters.
+
+| Block         | Files                                      | Rule(s)                                                                         |
+| :------------ | :----------------------------------------- | :------------------------------------------------------------------------------ |
+| JavaScript/TS | `**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,vue}` | base lint rules + `prettier/prettier`                                           |
+| JSON          | `**/*.json`                                | `prettier/prettier`                                                             |
+| Markdown      | `**/*.md`                                  | `prettier/prettier`, `markdown/*`, `markdown-links/*`, `markdown-preferences/*` |
+| YAML          | `**/*.{yml,yaml}`                          | `prettier/prettier`                                                             |
+
+### Linting hidden directories
+
+ESLint's CLI walker skips dot-directories such as `.github/` when you run `eslint .`. Because the formatter blocks
+above match against file paths, they will silently _not_ run on files inside `.github/` unless you pass that path to
+ESLint explicitly. The recommended lint script is therefore:
+
+```json
+{
+    "scripts": {
+        "lint": "eslint . .github"
+    }
+}
+```
+
+### Customizing or disabling the formatter on a file family
+
+Because the blocks are plain flat config, override them the same way as any other ESLint config — add a later block
+whose `files` glob overlaps the one you want to change. Later blocks win.
+
+Disable prettier formatting for JSON entirely:
+
+```javascript
+export default [
+    ...baseWithPrettierConfig,
+    { files: [ '**/*.json' ], rules: { 'prettier/prettier': 'off' } }
+];
+```
+
+Ignore specific paths from formatting:
+
+```javascript
+export default [
+    ...baseWithPrettierConfig,
+    { ignores: [ 'vendor/**/*.json', 'fixtures/**/*.md' ] }
+];
+```
+
+### Tweaking markdown lint rules
+
+To override any markdown rule (from `@eslint/markdown`, `markdown-links`, or `markdown-preferences`), add a later
+block — the same pattern as for any other ESLint rule:
+
+```javascript
+export default [
+    ...baseWithPrettierConfig,
+    {
+        files: [ '**/*.md' ],
+        rules: {
+            'markdown/no-html': 'off',
+            'markdown/fenced-code-language': [ 'error', { required: [ 'js', 'ts' ] } ],
+            'markdown-links/no-dead-urls': 'error',
+            'markdown-preferences/heading-casing': [ 'error', { style: 'Sentence case' } ]
+        }
+    }
+];
+```
+
+## Limitations
+
+- **No TOML coverage.** Prettier does not natively format `.toml` files. If you need TOML formatting, either use
+  [`@enormora/eslint-config-base`](../base/base.md) (which formats TOML via dprint) or wire your own prettier plugin
+  for TOML.

--- a/configs/presets/base/markdown-lint-rules.js
+++ b/configs/presets/base/markdown-lint-rules.js
@@ -1,0 +1,98 @@
+import markdownPlugin from '@eslint/markdown';
+import markdownLinksPlugin from 'eslint-plugin-markdown-links';
+import markdownPreferencesPlugin from 'eslint-plugin-markdown-preferences';
+
+export const markdownLintPlugins = {
+    markdown: markdownPlugin,
+    'markdown-links': markdownLinksPlugin,
+    'markdown-preferences': markdownPreferencesPlugin
+};
+
+export const markdownLintRules = {
+    'markdown/fenced-code-language': 'error',
+    'markdown/fenced-code-meta': 'off',
+    'markdown/heading-increment': 'error',
+    'markdown/no-bare-urls': 'error',
+    'markdown/no-duplicate-definitions': 'error',
+    'markdown/no-duplicate-headings': 'error',
+    'markdown/no-empty-definitions': 'error',
+    'markdown/no-empty-images': 'error',
+    'markdown/no-empty-links': 'error',
+    'markdown/no-html': 'error',
+    'markdown/no-invalid-label-refs': 'error',
+    'markdown/no-missing-atx-heading-space': 'error',
+    'markdown/no-missing-label-refs': 'error',
+    'markdown/no-missing-link-fragments': 'error',
+    'markdown/no-multiple-h1': 'error',
+    'markdown/no-reference-like-urls': 'error',
+    'markdown/no-reversed-media-syntax': 'error',
+    'markdown/no-space-in-emphasis': 'error',
+    'markdown/no-unused-definitions': 'error',
+    'markdown/require-alt-text': 'error',
+    'markdown/table-column-count': 'error',
+
+    // markdown-links: external network check is opt-in to keep CI deterministic;
+    // local-path and fragment checks are pure wins.
+    'markdown-links/no-dead-urls': 'off',
+    'markdown-links/no-missing-fragments': 'error',
+    'markdown-links/no-missing-path': 'error',
+    'markdown-links/no-self-destination': 'error',
+
+    // markdown-preferences: many rules overlap with the active markdown formatter (dprint or
+    // prettier, depending on which base preset is used). We enable only the 8 rules from this
+    // plugin's `recommended` config (none of which fight either formatter) and explicitly turn
+    // the other 45 off. Override individually if a stricter style is desired.
+    'markdown-preferences/atx-heading-closing-sequence': 'off',
+    'markdown-preferences/atx-heading-closing-sequence-length': 'off',
+    'markdown-preferences/blockquote-marker-alignment': 'error',
+    'markdown-preferences/bullet-list-marker-style': 'off',
+    'markdown-preferences/canonical-code-block-language': 'off',
+    'markdown-preferences/code-fence-length': 'off',
+    'markdown-preferences/code-fence-spacing': 'off',
+    'markdown-preferences/code-fence-style': 'off',
+    'markdown-preferences/custom-container-marker-spacing': 'off',
+    'markdown-preferences/definitions-last': 'off',
+    'markdown-preferences/emoji-notation': 'off',
+    'markdown-preferences/emphasis-delimiters-style': 'off',
+    'markdown-preferences/hard-linebreak-style': 'error',
+    'markdown-preferences/heading-casing': 'off',
+    'markdown-preferences/indent': 'off',
+    'markdown-preferences/level1-heading-style': 'off',
+    'markdown-preferences/level2-heading-style': 'off',
+    'markdown-preferences/link-bracket-newline': 'off',
+    'markdown-preferences/link-bracket-spacing': 'off',
+    'markdown-preferences/link-destination-style': 'off',
+    'markdown-preferences/link-paren-newline': 'off',
+    'markdown-preferences/link-paren-spacing': 'off',
+    'markdown-preferences/link-title-style': 'off',
+    'markdown-preferences/list-marker-alignment': 'error',
+    'markdown-preferences/max-len': 'off',
+    'markdown-preferences/no-heading-trailing-punctuation': 'off',
+    'markdown-preferences/no-implicit-block-closing': 'error',
+    'markdown-preferences/no-laziness-blockquotes': 'error',
+    'markdown-preferences/no-multi-spaces': 'off',
+    'markdown-preferences/no-multiple-empty-lines': 'off',
+    'markdown-preferences/no-tabs': 'off',
+    'markdown-preferences/no-text-backslash-linebreak': 'error',
+    'markdown-preferences/no-trailing-spaces': 'off',
+    'markdown-preferences/ordered-list-marker-sequence': 'off',
+    'markdown-preferences/ordered-list-marker-start': 'off',
+    'markdown-preferences/ordered-list-marker-style': 'off',
+    'markdown-preferences/padded-custom-containers': 'off',
+    'markdown-preferences/padding-line-between-blocks': 'off',
+    'markdown-preferences/prefer-autolinks': 'error',
+    'markdown-preferences/prefer-fenced-code-blocks': 'error',
+    'markdown-preferences/prefer-inline-code-words': 'off',
+    'markdown-preferences/prefer-link-reference-definitions': 'off',
+    'markdown-preferences/prefer-linked-words': 'off',
+    'markdown-preferences/setext-heading-underline-length': 'off',
+    'markdown-preferences/sort-definitions': 'off',
+    'markdown-preferences/strikethrough-delimiters-style': 'off',
+    'markdown-preferences/table-header-casing': 'off',
+    'markdown-preferences/table-leading-trailing-pipes': 'off',
+    'markdown-preferences/table-pipe-alignment': 'off',
+    'markdown-preferences/table-pipe-spacing': 'off',
+    'markdown-preferences/thematic-break-character-style': 'off',
+    'markdown-preferences/thematic-break-length': 'off',
+    'markdown-preferences/thematic-break-sequence-pattern': 'off'
+};

--- a/configs/presets/base/markdown.js
+++ b/configs/presets/base/markdown.js
@@ -1,7 +1,4 @@
 import dprintPlugin from '@ben_12/eslint-plugin-dprint';
-import markdownPlugin from '@eslint/markdown';
-import markdownLinksPlugin from 'eslint-plugin-markdown-links';
-import markdownPreferencesPlugin from 'eslint-plugin-markdown-preferences';
 import {
     jsonDprintConfig,
     markdownDprintConfig,
@@ -10,6 +7,7 @@ import {
     yamlDprintConfig
 } from './dprint-config.js';
 import { dprintSettings } from './dprint-formatters.js';
+import { markdownLintPlugins, markdownLintRules } from './markdown-lint-rules.js';
 
 // `@eslint/markdown` declares `language: 'markdown/commonmark'` for .md files, which makes ESLint
 // parse them into an mdast tree (root node `type: 'root'`). The stock `dprint/markdown` rule listens
@@ -32,9 +30,7 @@ const dprintMarkdownLanguageAdapter = {
 export const markdownConfig = {
     files: [ '**/*.md' ],
     plugins: {
-        markdown: markdownPlugin,
-        'markdown-links': markdownLinksPlugin,
-        'markdown-preferences': markdownPreferencesPlugin,
+        ...markdownLintPlugins,
         'dprint-markdown': dprintMarkdownLanguageAdapter
     },
     // Pinned to commonmark because @eslint/markdown@8.0.2's MarkdownSourceCode does not implement
@@ -58,90 +54,6 @@ export const markdownConfig = {
             }
         ],
 
-        'markdown/fenced-code-language': 'error',
-        'markdown/fenced-code-meta': 'off',
-        'markdown/heading-increment': 'error',
-        'markdown/no-bare-urls': 'error',
-        'markdown/no-duplicate-definitions': 'error',
-        'markdown/no-duplicate-headings': 'error',
-        'markdown/no-empty-definitions': 'error',
-        'markdown/no-empty-images': 'error',
-        'markdown/no-empty-links': 'error',
-        'markdown/no-html': 'error',
-        'markdown/no-invalid-label-refs': 'error',
-        'markdown/no-missing-atx-heading-space': 'error',
-        'markdown/no-missing-label-refs': 'error',
-        'markdown/no-missing-link-fragments': 'error',
-        'markdown/no-multiple-h1': 'error',
-        'markdown/no-reference-like-urls': 'error',
-        'markdown/no-reversed-media-syntax': 'error',
-        'markdown/no-space-in-emphasis': 'error',
-        'markdown/no-unused-definitions': 'error',
-        'markdown/require-alt-text': 'error',
-        'markdown/table-column-count': 'error',
-
-        // markdown-links: external network check is opt-in to keep CI deterministic;
-        // local-path and fragment checks are pure wins.
-        'markdown-links/no-dead-urls': 'off',
-        'markdown-links/no-missing-fragments': 'error',
-        'markdown-links/no-missing-path': 'error',
-        'markdown-links/no-self-destination': 'error',
-
-        // markdown-preferences: many rules overlap with dprint/markdown formatting. We enable only
-        // the 8 rules from this plugin's `recommended` config (none of which fight dprint) and
-        // explicitly turn the other 45 off. Override individually if a stricter style is desired.
-        'markdown-preferences/atx-heading-closing-sequence': 'off',
-        'markdown-preferences/atx-heading-closing-sequence-length': 'off',
-        'markdown-preferences/blockquote-marker-alignment': 'error',
-        'markdown-preferences/bullet-list-marker-style': 'off',
-        'markdown-preferences/canonical-code-block-language': 'off',
-        'markdown-preferences/code-fence-length': 'off',
-        'markdown-preferences/code-fence-spacing': 'off',
-        'markdown-preferences/code-fence-style': 'off',
-        'markdown-preferences/custom-container-marker-spacing': 'off',
-        'markdown-preferences/definitions-last': 'off',
-        'markdown-preferences/emoji-notation': 'off',
-        'markdown-preferences/emphasis-delimiters-style': 'off',
-        'markdown-preferences/hard-linebreak-style': 'error',
-        'markdown-preferences/heading-casing': 'off',
-        'markdown-preferences/indent': 'off',
-        'markdown-preferences/level1-heading-style': 'off',
-        'markdown-preferences/level2-heading-style': 'off',
-        'markdown-preferences/link-bracket-newline': 'off',
-        'markdown-preferences/link-bracket-spacing': 'off',
-        'markdown-preferences/link-destination-style': 'off',
-        'markdown-preferences/link-paren-newline': 'off',
-        'markdown-preferences/link-paren-spacing': 'off',
-        'markdown-preferences/link-title-style': 'off',
-        'markdown-preferences/list-marker-alignment': 'error',
-        'markdown-preferences/max-len': 'off',
-        'markdown-preferences/no-heading-trailing-punctuation': 'off',
-        'markdown-preferences/no-implicit-block-closing': 'error',
-        'markdown-preferences/no-laziness-blockquotes': 'error',
-        'markdown-preferences/no-multi-spaces': 'off',
-        'markdown-preferences/no-multiple-empty-lines': 'off',
-        'markdown-preferences/no-tabs': 'off',
-        'markdown-preferences/no-text-backslash-linebreak': 'error',
-        'markdown-preferences/no-trailing-spaces': 'off',
-        'markdown-preferences/ordered-list-marker-sequence': 'off',
-        'markdown-preferences/ordered-list-marker-start': 'off',
-        'markdown-preferences/ordered-list-marker-style': 'off',
-        'markdown-preferences/padded-custom-containers': 'off',
-        'markdown-preferences/padding-line-between-blocks': 'off',
-        'markdown-preferences/prefer-autolinks': 'error',
-        'markdown-preferences/prefer-fenced-code-blocks': 'error',
-        'markdown-preferences/prefer-inline-code-words': 'off',
-        'markdown-preferences/prefer-link-reference-definitions': 'off',
-        'markdown-preferences/prefer-linked-words': 'off',
-        'markdown-preferences/setext-heading-underline-length': 'off',
-        'markdown-preferences/sort-definitions': 'off',
-        'markdown-preferences/strikethrough-delimiters-style': 'off',
-        'markdown-preferences/table-header-casing': 'off',
-        'markdown-preferences/table-leading-trailing-pipes': 'off',
-        'markdown-preferences/table-pipe-alignment': 'off',
-        'markdown-preferences/table-pipe-spacing': 'off',
-        'markdown-preferences/thematic-break-character-style': 'off',
-        'markdown-preferences/thematic-break-length': 'off',
-        'markdown-preferences/thematic-break-sequence-pattern': 'off'
+        ...markdownLintRules
     }
 };

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -8,6 +8,8 @@ const noDuplicatedFilesAllowList = [
     'LICENSE',
     'configs/constants.js',
     'configs/presets/base/base-shared.js',
+    'configs/presets/base/cspell-config.js',
+    'configs/presets/base/markdown-lint-rules.js',
     'configs/rule-sets/best-practices.js',
     'configs/rule-sets/restricted-syntax.js',
     'configs/rule-sets/stylistic.js'

--- a/test/base-with-prettier.test.js
+++ b/test/base-with-prettier.test.js
@@ -1,7 +1,10 @@
-import eslintCommentsPlugin from '@eslint-community/eslint-plugin-eslint-comments';
+import { rules as eslintCommentsPluginRules } from '@eslint-community/eslint-plugin-eslint-comments';
+import markdownPlugin from '@eslint/markdown';
 import { suite, test } from 'mocha';
 import { rules as importPluginRules } from 'eslint-plugin-import-x';
-import noSecretsPlugin from 'eslint-plugin-no-secrets';
+import { rules as markdownLinksPluginRules } from 'eslint-plugin-markdown-links';
+import { rules as markdownPreferencesPluginRules } from 'eslint-plugin-markdown-preferences';
+import { rules as noSecretsPluginRules } from 'eslint-plugin-no-secrets';
 import prettierPlugin from 'eslint-plugin-prettier';
 import { baseWithPrettierConfig } from '../configs/presets/base-with-prettier/base-with-prettier.js';
 import {
@@ -9,91 +12,50 @@ import {
     checkAllPluginRulesConfigured,
     checkConfigToHaveNoValidationIssues,
     checkUnknownCoreRulesAreNotConfigured,
-    checkUnknownPluginRulesAreNotConfigured
+    checkUnknownPluginRulesAreNotConfigured,
+    mergeConfigRules
 } from './rules-configuration.js';
 
-suite('base-with-prettier preset', function () {
-    suite('base rules', function () {
-        test('all core rules are configured', function () {
-            checkAllCoreRulesConfigured({
-                ruleConfigSet: baseWithPrettierConfig.rules
-            });
-        });
+const baseWithPrettierConfigRules = mergeConfigRules(baseWithPrettierConfig);
 
-        test('does not contain removed core rules', function () {
-            checkUnknownCoreRulesAreNotConfigured({
-                ruleConfigSet: baseWithPrettierConfig.rules
-            });
-        });
-
-        test('all eslint-plugin-no-secrets rules are configured', function () {
+function pluginCoverageSuite(pluginName, pluginRules) {
+    suite(pluginName, function () {
+        test('all rules are configured', function () {
             checkAllPluginRulesConfigured({
-                ruleConfigSet: baseWithPrettierConfig.rules,
-                pluginRules: noSecretsPlugin.rules,
-                pluginName: 'eslint-plugin-no-secrets'
+                ruleConfigSet: baseWithPrettierConfigRules,
+                pluginRules,
+                pluginName
             });
         });
 
-        test('no unknown eslint-plugin-no-secrets rules are configured', function () {
+        test('no unknown rules are configured', function () {
             checkUnknownPluginRulesAreNotConfigured({
-                ruleConfigSet: baseWithPrettierConfig.rules,
-                pluginRules: noSecretsPlugin.rules,
-                pluginName: 'eslint-plugin-no-secrets'
-            });
-        });
-
-        test('all eslint-plugin-import rules are configured', function () {
-            checkAllPluginRulesConfigured({
-                ruleConfigSet: baseWithPrettierConfig.rules,
-                pluginRules: importPluginRules,
-                pluginName: 'eslint-plugin-import'
-            });
-        });
-
-        test('no unknown eslint-plugin-import rules are configured', function () {
-            checkUnknownPluginRulesAreNotConfigured({
-                ruleConfigSet: baseWithPrettierConfig.rules,
-                pluginRules: importPluginRules,
-                pluginName: 'eslint-plugin-import'
+                ruleConfigSet: baseWithPrettierConfigRules,
+                pluginRules,
+                pluginName
             });
         });
     });
+}
 
-    suite('plugin coverage', function () {
-        test('all @eslint-community/eslint-plugin-eslint-comments rules are configured', function () {
-            checkAllPluginRulesConfigured({
-                ruleConfigSet: baseWithPrettierConfig.rules,
-                pluginRules: eslintCommentsPlugin.rules,
-                pluginName: 'eslint-plugin-eslint-comments'
-            });
-        });
+suite('base-with-prettier preset', function () {
+    test('all core rules are configured', function () {
+        checkAllCoreRulesConfigured({ ruleConfigSet: baseWithPrettierConfigRules });
+    });
 
-        test('no unknown @eslint-community/eslint-plugin-eslint-comments rules are configured', function () {
-            checkUnknownPluginRulesAreNotConfigured({
-                ruleConfigSet: baseWithPrettierConfig.rules,
-                pluginRules: eslintCommentsPlugin.rules,
-                pluginName: 'eslint-plugin-eslint-comments'
-            });
-        });
+    test('does not contain removed core rules', function () {
+        checkUnknownCoreRulesAreNotConfigured({ ruleConfigSet: baseWithPrettierConfigRules });
+    });
 
-        test('all eslint-plugin-prettier rules are configured', function () {
-            checkAllPluginRulesConfigured({
-                ruleConfigSet: baseWithPrettierConfig.rules,
-                pluginRules: prettierPlugin.rules,
-                pluginName: 'eslint-plugin-prettier'
-            });
-        });
+    pluginCoverageSuite('eslint-plugin-no-secrets', noSecretsPluginRules);
+    pluginCoverageSuite('eslint-plugin-import', importPluginRules);
+    pluginCoverageSuite('eslint-plugin-eslint-comments', eslintCommentsPluginRules);
+    pluginCoverageSuite('eslint-plugin-prettier', prettierPlugin.rules);
+    pluginCoverageSuite('@eslint/markdown', markdownPlugin.rules);
+    pluginCoverageSuite('eslint-plugin-markdown-links', markdownLinksPluginRules);
+    pluginCoverageSuite('eslint-plugin-markdown-preferences', markdownPreferencesPluginRules);
 
-        test('no unknown eslint-plugin-prettier rules are configured', function () {
-            checkUnknownPluginRulesAreNotConfigured({
-                ruleConfigSet: baseWithPrettierConfig.rules,
-                pluginRules: prettierPlugin.rules,
-                pluginName: 'eslint-plugin-prettier'
-            });
-        });
-
-        test('base-with-prettier preset config has no validation errors', function () {
-            checkConfigToHaveNoValidationIssues(baseWithPrettierConfig);
-        });
+    test('base-with-prettier preset config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(baseWithPrettierConfig);
     });
 });


### PR DESCRIPTION
`baseWithPrettierConfig` had drifted from `baseConfig`: it was a single config object with no `files` scope, no markdown/JSON/YAML coverage, and `@stylistic/member-delimiter-style` left active alongside `prettier/prettier`. That contradicted the readme's claim of a drop-in alternative to `@enormora/eslint-config-base`.

The preset is now an array of blocks mirroring base's shape — JS/TS scoped to the same glob with the delimiter rule off, plus `prettier/prettier` blocks for JSON, YAML, and Markdown. The Markdown block additionally enables the same semantic linters as base (`markdown/*`, `markdown-links/*`, `markdown-preferences/*`) via a new shared `base/markdown-lint-rules.js` module that both presets import, eliminating future drift. TOML stays uncovered because prettier has no native TOML support, and the readme's Limitations section calls that out.
