### PR TITLE
Add `no-unnecessary-arrow-function` rule to prefer regular function expressions

### DIFF
--- a/configs/presets/base/base-shared.js
+++ b/configs/presets/base/base-shared.js
@@ -9,7 +9,8 @@ import {
     noClassDeclarationRestriction,
     noEmptyFunctionBodyRestriction,
     noInOperatorRestriction,
-    noSwitchStatementRestriction
+    noSwitchStatementRestriction,
+    noUnnecessaryArrowFunctionRestriction
 } from '../../rule-sets/restricted-syntax.js';
 import { stylisticRuleSet } from '../../rule-sets/stylistic.js';
 
@@ -17,7 +18,8 @@ const restrictedSyntaxPlugin = createRestrictedSyntaxPlugin([
     'no-class-declaration',
     'no-switch-statement',
     'no-empty-function-body',
-    'no-in-operator'
+    'no-in-operator',
+    'no-unnecessary-arrow-function'
 ]);
 
 export const cspellSpellcheckerOptions = {
@@ -156,6 +158,7 @@ export const baseSharedConfig = {
         'restricted-syntax/no-switch-statement': [ 'error', noSwitchStatementRestriction ],
         'restricted-syntax/no-empty-function-body': [ 'error', noEmptyFunctionBodyRestriction ],
         'restricted-syntax/no-in-operator': [ 'error', noInOperatorRestriction ],
+        'restricted-syntax/no-unnecessary-arrow-function': [ 'error', noUnnecessaryArrowFunctionRestriction ],
         'no-return-assign': [ 'error', 'always' ],
         'no-self-assign': [ 'error', { props: true } ],
         'no-self-compare': 'error',
@@ -278,12 +281,7 @@ export const baseSharedConfig = {
         'object-shorthand': [ 'error', 'always' ],
         'one-var': [ 'error', 'never' ],
         'operator-assignment': [ 'error', 'always' ],
-        'prefer-arrow-callback': [
-            'error',
-            {
-                allowNamedFunctions: true
-            }
-        ],
+        'prefer-arrow-callback': 'off',
         'prefer-rest-params': 'error',
         radix: 'error',
         'id-match': 'off',

--- a/configs/rule-sets/best-practices.js
+++ b/configs/rule-sets/best-practices.js
@@ -13,16 +13,16 @@ function isSonarjsRuleDeprecated(sonarjsRule) {
 const nonDeprecatedSonarjsRuleNames = new Set(
     Object
         .entries(sonarjsPlugin.rules)
-        .filter(([ , sonarjsRule ]) => {
+        .filter(function removeDeprecated([ , sonarjsRule ]) {
             return !isSonarjsRuleDeprecated(sonarjsRule);
         })
-        .map(([ sonarjsRuleName ]) => {
+        .map(function toQualifiedRuleName([ sonarjsRuleName ]) {
             return `sonarjs/${sonarjsRuleName}`;
         })
 );
 
 const nonDeprecatedSonarjsRecommendedRules = Object.fromEntries(
-    Object.entries(sonarjsPlugin.configs.recommended.rules).filter(([ sonarjsRuleName ]) => {
+    Object.entries(sonarjsPlugin.configs.recommended.rules).filter(function keepNonDeprecated([ sonarjsRuleName ]) {
         return nonDeprecatedSonarjsRuleNames.has(sonarjsRuleName);
     })
 );

--- a/configs/rule-sets/restricted-syntax.js
+++ b/configs/rule-sets/restricted-syntax.js
@@ -5,7 +5,7 @@ const noRestrictedSyntaxRule = builtinRules.get('no-restricted-syntax');
 export function createRestrictedSyntaxPlugin(ruleNames) {
     return {
         rules: Object.fromEntries(
-            ruleNames.map((ruleName) => {
+            ruleNames.map(function toRuleEntry(ruleName) {
                 return [ ruleName, noRestrictedSyntaxRule ];
             })
         )
@@ -33,7 +33,7 @@ export const noSwitchStatementRestriction = {
 };
 
 const emptyFunctionBodySelector = [ 'FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression' ]
-    .map((kind) => {
+    .map(function toEmptyBodySelector(kind) {
         return `${kind} > BlockStatement[body.length=0]`;
     })
     .join(', ');
@@ -46,4 +46,17 @@ export const noEmptyFunctionBodyRestriction = {
 export const noInOperatorRestriction = {
     selector: 'BinaryExpression[operator="in"]',
     message: 'The `in` operator is not allowed. Use `Object.hasOwn` instead.'
+};
+
+const lexicalBindingReferences = [
+    'ThisExpression',
+    'Super',
+    'MetaProperty[meta.name="new"]',
+    'Identifier[name="arguments"]'
+]
+    .join(', ');
+
+export const noUnnecessaryArrowFunctionRestriction = {
+    selector: `ArrowFunctionExpression:not(:has(${lexicalBindingReferences}))`,
+    message: 'Arrow functions are only allowed when they use lexical `this`, `super`, `new.target`, or `arguments`.'
 };

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -14,7 +14,7 @@ const noDuplicatedFilesAllowList = [
     'configs/rule-sets/restricted-syntax.js',
     'configs/rule-sets/stylistic.js'
 ]
-    .map((filePath) => {
+    .map(function toAbsolutePath(filePath) {
         return path.join(projectFolder, filePath);
     });
 const publishingPeerDependencies = {

--- a/test/cspell-helper.test.js
+++ b/test/cspell-helper.test.js
@@ -5,7 +5,7 @@ import { withCspellWords } from '../configs/presets/base/cspell-config.js';
 
 function cloneOptions(value) {
     if (Array.isArray(value)) {
-        return value.map((item) => {
+        return value.map(function cloneItem(item) {
             return cloneOptions(item);
         });
     }

--- a/test/integration/base-markdown.test.js
+++ b/test/integration/base-markdown.test.js
@@ -46,7 +46,7 @@ suite('base markdown integration', function () {
 
     test('base markdown clean fixture produces no reports', async function () {
         const { messages } = await lintFixture(configs, comboName, 'clean.md');
-        const detail = messages.map((message) => {
+        const detail = messages.map(function toReportDetail(message) {
             return { ruleId: message.ruleId, line: message.line, message: message.message };
         });
         assert.deepStrictEqual(detail, []);

--- a/test/integration/base-node.test.js
+++ b/test/integration/base-node.test.js
@@ -47,7 +47,6 @@ const expectedViolationRuleIds = [
     'node/no-process-exit',
     'node/no-sync',
     'operator-assignment',
-    'prefer-arrow-callback',
     'prefer-template',
     'promise/catch-or-return',
     'restricted-syntax/no-empty-function-body',
@@ -80,7 +79,7 @@ suite('base+node integration', function () {
 
     test('base+node clean fixture produces no reports', async function () {
         const { messages } = await lintFixture(configs, comboName, 'clean.js');
-        const detail = messages.map((message) => {
+        const detail = messages.map(function toReportDetail(message) {
             return { ruleId: message.ruleId, line: message.line, message: message.message };
         });
         assert.deepStrictEqual(detail, []);

--- a/test/integration/base-typescript-node.test.js
+++ b/test/integration/base-typescript-node.test.js
@@ -88,6 +88,7 @@ const expectedViolationRuleIds = [
     'restricted-syntax/no-class-declaration',
     'restricted-syntax/no-empty-function-body',
     'restricted-syntax/no-switch-statement',
+    'restricted-syntax/no-unnecessary-arrow-function',
     'sonarjs/deprecation',
     'sonarjs/no-alphabetical-sort',
     'sonarjs/no-collapsible-if',
@@ -121,7 +122,7 @@ suite('base+typescript+node integration', function () {
 
     test('base+typescript+node clean fixture produces no reports', async function () {
         const { messages } = await lintFixture(configs, comboName, 'clean.ts');
-        const detail = messages.map((message) => {
+        const detail = messages.map(function toReportDetail(message) {
             return { ruleId: message.ruleId, line: message.line, message: message.message };
         });
         assert.deepStrictEqual(detail, []);

--- a/test/integration/base-typescript-react-tsx.test.js
+++ b/test/integration/base-typescript-react-tsx.test.js
@@ -37,6 +37,7 @@ const expectedViolationRuleIds = [
     'react/jsx-no-target-blank',
     'react/react-in-jsx-scope',
     'restricted-syntax-typescript/no-inline-signature-type-literal',
+    'restricted-syntax/no-unnecessary-arrow-function',
     'sonarjs/prefer-read-only-props'
 ];
 
@@ -48,7 +49,7 @@ suite('base+typescript+react-tsx integration', function () {
 
     test('base+typescript+react-tsx clean fixture produces no reports', async function () {
         const { messages } = await lintFixture(configs, comboName, 'clean.tsx');
-        const detail = messages.map((message) => {
+        const detail = messages.map(function toReportDetail(message) {
             return { ruleId: message.ruleId, line: message.line, message: message.message };
         });
         assert.deepStrictEqual(detail, []);

--- a/test/integration/base-typescript.test.js
+++ b/test/integration/base-typescript.test.js
@@ -78,13 +78,13 @@ const expectedViolationRuleIds = [
     'no-var',
     'no-warning-comments',
     'operator-assignment',
-    'prefer-arrow-callback',
     'prefer-template',
     'promise/catch-or-return',
     'restricted-syntax-typescript/no-inline-signature-type-literal',
     'restricted-syntax/no-class-declaration',
     'restricted-syntax/no-empty-function-body',
     'restricted-syntax/no-switch-statement',
+    'restricted-syntax/no-unnecessary-arrow-function',
     'sonarjs/deprecation',
     'sonarjs/no-alphabetical-sort',
     'sonarjs/no-collapsible-if',
@@ -118,7 +118,7 @@ suite('base+typescript integration', function () {
 
     test('base+typescript clean fixture produces no reports', async function () {
         const { messages } = await lintFixture(configs, comboName, 'clean.ts');
-        const detail = messages.map((message) => {
+        const detail = messages.map(function toRuleLocation(message) {
             return { ruleId: message.ruleId, line: message.line, message: message.message };
         });
         assert.deepStrictEqual(detail, []);
@@ -135,11 +135,11 @@ suite('base+typescript integration', function () {
     test('base+typescript built-in mutable classes do not poison immutability checks', async function () {
         const { messages } = await lintFixture(configs, comboName, 'builtin-classes.ts');
         const immutabilityMessages = messages
-            .filter((message) => {
+            .filter(function isImmutabilityMessage(message) {
                 return message.ruleId === 'functional/prefer-immutable-types' ||
                     message.ruleId === 'functional/type-declaration-immutability';
             })
-            .map((message) => {
+            .map(function toRuleLocation(message) {
                 return { ruleId: message.ruleId, line: message.line, message: message.message };
             });
         assert.deepStrictEqual(immutabilityMessages, []);
@@ -149,19 +149,19 @@ suite('base+typescript integration', function () {
         const { messages } = await lintFixture(configs, comboName, 'named-class-type-parameters.ts');
         const flaggedLines = new Set(
             messages
-                .filter((message) => {
+                .filter(function isImmutableTypesMessage(message) {
                     return message.ruleId === 'functional/prefer-immutable-types';
                 })
-                .map((message) => {
+                .map(function toLine(message) {
                     return message.line;
                 })
         );
         const acceptedNamedTypeLines = new Set([ 33, 34, 35, 36, 37 ]);
         const expectedInlineMutableLines = new Set([ 40, 41, 42, 43, 44 ]);
-        const unexpectedNamedTypeReports = Array.from(acceptedNamedTypeLines).filter((line) => {
+        const unexpectedNamedTypeReports = Array.from(acceptedNamedTypeLines).filter(function isFlagged(line) {
             return flaggedLines.has(line);
         });
-        const missingInlineMutableReports = Array.from(expectedInlineMutableLines).filter((line) => {
+        const missingInlineMutableReports = Array.from(expectedInlineMutableLines).filter(function isNotFlagged(line) {
             return !flaggedLines.has(line);
         });
         assert.deepStrictEqual(unexpectedNamedTypeReports, [], 'named class/interface parameters must not be flagged');

--- a/test/integration/lint-fixture.js
+++ b/test/integration/lint-fixture.js
@@ -19,10 +19,10 @@ export async function lintFixture(configs, comboName, filename) {
 }
 
 export function uniqueSortedRuleIds(messages) {
-    const ruleIds = messages.map((message) => {
+    const ruleIds = messages.map(function extractRuleId(message) {
         return message.ruleId;
     });
-    const definedRuleIds = ruleIds.filter((ruleId) => {
+    const definedRuleIds = ruleIds.filter(function keepDefinedRuleId(ruleId) {
         return ruleId !== null && ruleId !== undefined;
     });
     return Array.from(new Set(definedRuleIds)).toSorted();

--- a/test/restricted-syntax.test.js
+++ b/test/restricted-syntax.test.js
@@ -8,7 +8,8 @@ import {
     noClassDeclarationRestriction,
     noEmptyFunctionBodyRestriction,
     noInOperatorRestriction,
-    noSwitchStatementRestriction
+    noSwitchStatementRestriction,
+    noUnnecessaryArrowFunctionRestriction
 } from '../configs/rule-sets/restricted-syntax.js';
 import {
     noInlineSignatureTypeLiteralRestriction,
@@ -30,22 +31,22 @@ const typescriptRuleTester = new RuleTester({
 });
 
 function runRuleCases(ruleTester, restriction, cases) {
-    const valid = cases.valid.map((code) => {
+    const valid = cases.valid.map(function attachRestrictionOption(code) {
         return { code, options: [ restriction ] };
     });
-    const invalid = cases.invalid.map((entry) => {
+    const invalid = cases.invalid.map(function buildExpectedErrors(entry) {
         const code = typeof entry === 'string' ? entry : entry.code;
         const count = typeof entry === 'string' ? 1 : entry.count;
         return {
             code,
             options: [ restriction ],
-            errors: Array.from({ length: count }, () => {
+            errors: Array.from({ length: count }, function expectRestrictionMessage() {
                 return { message: restriction.message };
             })
         };
     });
 
-    assert.doesNotThrow(() => {
+    assert.doesNotThrow(function runWithoutThrowing() {
         ruleTester.run('no-restricted-syntax', noRestrictedSyntaxRule, { valid, invalid });
     });
 }
@@ -128,6 +129,27 @@ suite('restricted syntax rules', function () {
                 'if ("foo" in bar) {}',
                 'const has = "foo" in bar;',
                 'function check(obj) { return "key" in obj; }'
+            ]
+        });
+    });
+
+    test('noUnnecessaryArrowFunctionRestriction permits only arrows relying on lexical binding', function () {
+        runRuleCases(javascriptRuleTester, noUnnecessaryArrowFunctionRestriction, {
+            valid: [
+                'const handler = () => { return this.value; };',
+                'element.addEventListener("click", () => { this.handle(); });',
+                'const first = () => { return arguments[0]; };',
+                'class Base { build() { return () => { return super.build(); }; } }',
+                'function Factory() { return () => { return new.target; }; }',
+                'function double(x) { return x * 2; }',
+                'const add = function (a, b) { return a + b; };',
+                'items.map(function (item) { return item.id; });'
+            ],
+            invalid: [
+                'const noop = () => { return 1; };',
+                'items.map((item) => item.id);',
+                'const add = (a, b) => { return a + b; };',
+                { code: 'const compose = () => { return () => { return 1; }; };', count: 2 }
             ]
         });
     });

--- a/test/rules-configuration.js
+++ b/test/rules-configuration.js
@@ -31,7 +31,7 @@ export function checkAllCoreRulesConfigured(testCase) {
 
     assert.notStrictEqual(ruleNames.length, 0, 'ESLint core rules not found');
 
-    ruleNames.forEach((ruleName) => {
+    ruleNames.forEach(function assertCoreRuleConfigured(ruleName) {
         assert.strictEqual(
             isRuleConfigured(ruleConfigSet, ruleName),
             true,
@@ -44,11 +44,11 @@ export function checkUnknownCoreRulesAreNotConfigured(testCase) {
     const { ruleConfigSet } = testCase;
     const allCoreRuleNames = Object.keys(eslintCorePresets.configs.all.rules);
     const configuredRuleNames = Object.keys(ruleConfigSet);
-    const configuredCoreRuleNames = configuredRuleNames.filter((ruleName) => {
+    const configuredCoreRuleNames = configuredRuleNames.filter(function isCoreRuleName(ruleName) {
         return !ruleName.includes('/');
     });
 
-    configuredCoreRuleNames.forEach((ruleName) => {
+    configuredCoreRuleNames.forEach(function assertCoreRuleExists(ruleName) {
         assert.strictEqual(
             allCoreRuleNames.includes(ruleName),
             true,
@@ -65,10 +65,10 @@ export function checkAllPluginRulesConfigured(testCase) {
     assert.notStrictEqual(ruleNames.length, 0, 'Plugin rules are empty');
 
     ruleNames
-        .filter((ruleName) => {
+        .filter(function isNotExcluded(ruleName) {
             return !rulesToExclude.includes(ruleName);
         })
-        .forEach((ruleName) => {
+        .forEach(function assertPluginRuleConfigured(ruleName) {
             const rule = pluginRules[ruleName];
             const shortPluginRuleName = `${shortPluginName}/${ruleName}`;
             const isConfigured = isRuleConfigured(ruleConfigSet, shortPluginRuleName);
@@ -87,28 +87,28 @@ export function checkUnknownPluginRulesAreNotConfigured(testCase) {
     const shortPluginName = extractShortName(pluginName);
     const pluginRuleNames = Object
         .keys(pluginRules)
-        .filter((ruleName) => {
+        .filter(function isNotDeprecated(ruleName) {
             return !isRuleDeprecated(pluginRules[ruleName]);
         })
-        .map((ruleName) => {
+        .map(function prefixWithPluginName(ruleName) {
             return `${shortPluginName}/${ruleName}`;
         });
 
     assert.notStrictEqual(pluginRuleNames.length, 0, 'Plugin rules are empty');
 
     const configuredRuleNames = Object.keys(ruleConfigSet);
-    const configuredPluginRuleNames = configuredRuleNames.filter((ruleName) => {
+    const configuredPluginRuleNames = configuredRuleNames.filter(function belongsToPlugin(ruleName) {
         return ruleName.startsWith(`${shortPluginName}/`);
     });
 
-    configuredPluginRuleNames.forEach((ruleName) => {
+    configuredPluginRuleNames.forEach(function assertPluginRuleStillExists(ruleName) {
         assert.strictEqual(pluginRuleNames.includes(ruleName), true, `Rule ${ruleName} can be removed`);
     });
 }
 
 export function mergeConfigRules(config) {
     if (Array.isArray(config)) {
-        return config.reduce((merged, block) => {
+        return config.reduce(function collectBlockRules(merged, block) {
             return { ...merged, ...block.rules };
         }, {});
     }
@@ -146,7 +146,7 @@ export function checkConfigToHaveNoValidationIssues(config) {
 
     const verifiableConfig = Array.isArray(config) ? config.map(injectProgram) : injectProgram(config);
 
-    assert.doesNotThrow(() => {
+    assert.doesNotThrow(function verifyConfig() {
         linter.verify('foo();', verifiableConfig, '/foo.js');
     }, 'Linter.verify() failed for the given config');
 }
@@ -165,7 +165,7 @@ export function checkAllTestRulesConfigured(testCase) {
 
     assert.notStrictEqual(rulesFromConfigKeys.length, 0, 'Plugin rules are empty');
 
-    const remainingRulesKeys = rulesFromConfigKeys.filter((ruleName) => {
+    const remainingRulesKeys = rulesFromConfigKeys.filter(function isTestRuleName(ruleName) {
         return testRuleNames.includes(ruleName);
     });
 
@@ -179,13 +179,15 @@ export function checkAdditionalRulesConfigured(testCase) {
     const { ruleConfigSet, additionalRules } = testCase;
 
     const additionalRulesNames = Object.keys(additionalRules);
-    const additionalRulesFromRuleConfigSet = Object.entries(ruleConfigSet).filter(([ ruleName ]) => {
-        return additionalRulesNames.includes(ruleName);
-    });
+    const additionalRulesFromRuleConfigSet = Object.entries(ruleConfigSet).filter(
+        function isAdditionalRule([ ruleName ]) {
+            return additionalRulesNames.includes(ruleName);
+        }
+    );
 
     assert.notStrictEqual(additionalRulesFromRuleConfigSet.length, 0, 'Additional plugin rules are not defined');
 
-    additionalRulesFromRuleConfigSet.forEach(([ ruleName, ruleSetting ]) => {
+    additionalRulesFromRuleConfigSet.forEach(function assertAdditionalRuleSetting([ ruleName, ruleSetting ]) {
         const expectedRuleSetting = additionalRules[ruleName];
 
         assert.deepStrictEqual(


### PR DESCRIPTION
Introduces a `restricted-syntax/no-unnecessary-arrow-function` rule that limits arrow functions to the cases that genuinely need lexical binding (`this`, `super`, `new.target`, `arguments`) and requires a regular function expression everywhere else. It rides on the existing `restricted-syntax` plugin wiring in `base-shared.js`, so both the `base` and `base-with-prettier` presets pick it up.

`prefer-arrow-callback` is disabled because it enforced the inverse preference. Existing callbacks throughout `configs/` and `test/` are converted to regular function expressions to comply.