### PR TITLE
Cover `typeof`, unions, and utility-type compositions in immutability ignore patterns

### DIFF
--- a/configs/presets/typescript/typescript.js
+++ b/configs/presets/typescript/typescript.js
@@ -13,9 +13,12 @@ export const noTsEnumDeclarationRestriction = {
     message: 'Use a string union type instead'
 };
 
-const namedReferenceIgnorePattern =
-    String.raw`^(?!(?:Array|ReadonlyArray|Map|ReadonlyMap|Set|ReadonlySet|Record|Readonly)\b)` +
-    String.raw`[A-Z][\w$]*(?:\.[A-Z][\w$]*)*(?:<.*>)?$`;
+const namedReferenceTypePrefix = String.raw`(?:(?:keyof)?typeof)?`;
+const mutableContainerLookahead = String
+    .raw`(?!(?:Array|ReadonlyArray|Map|ReadonlyMap|Set|ReadonlySet|Record|Readonly)\b)`;
+const namedReferenceBody = String.raw`[A-Z][\w$]*(?:\.[A-Z][\w$]*)*(?:<.*>)?`;
+const namedReferenceAtom = `${namedReferenceTypePrefix}${mutableContainerLookahead}${namedReferenceBody}`;
+const namedReferenceIgnorePattern = String.raw`^${namedReferenceAtom}(?:[|&]${namedReferenceAtom})*$`;
 
 const functionLikeNodes = [
     'FunctionDeclaration',
@@ -481,6 +484,7 @@ export const typescriptConfig = {
                         ]
                     }
                 ],
+                ignoreTypePattern: [ namedReferenceIgnorePattern ],
                 ignoreInterfaces: false
             }
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "eslint-plugin-astro": "1.7.0",
                 "eslint-plugin-ava": "17.0.0",
                 "eslint-plugin-destructuring": "2.2.1",
-                "eslint-plugin-functional": "9.0.5",
+                "eslint-plugin-functional": "10.0.0",
                 "eslint-plugin-import-x": "4.16.2",
                 "eslint-plugin-jsx-a11y": "6.10.2",
                 "eslint-plugin-markdown-links": "0.9.0",
@@ -5154,9 +5154,9 @@
             }
         },
         "node_modules/eslint-plugin-functional": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-functional/-/eslint-plugin-functional-9.0.5.tgz",
-            "integrity": "sha512-RYbNpGkGu5mSN7xlezyeE7TE3S9rsliAS5FOorZoxn7126UTslcQnoVOIAOA6fMOlz6dNG3x3cd3tuzrHM6mRA==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-functional/-/eslint-plugin-functional-10.0.0.tgz",
+            "integrity": "sha512-D/BWdGUvPz5uIC+kZM1BWrELhjHpDiYxIYjzF7a6TZ62KINajjKgOiSYGbGv4fpMT1enEC9yG+0kOaIRTZzpTg==",
             "funding": [
                 {
                     "type": "ko-fi",
@@ -5177,7 +5177,7 @@
                 "ts-declaration-location": "^1.0.6"
             },
             "engines": {
-                "node": ">=v18.18.0"
+                "node": ">=v20.0.0"
             },
             "peerDependencies": {
                 "eslint": "^9.0.0 || ^10.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "eslint-plugin-astro": "1.7.0",
         "eslint-plugin-ava": "17.0.0",
         "eslint-plugin-destructuring": "2.2.1",
-        "eslint-plugin-functional": "9.0.5",
+        "eslint-plugin-functional": "10.0.0",
         "eslint-plugin-import-x": "4.16.2",
         "eslint-plugin-jsx-a11y": "6.10.2",
         "eslint-plugin-markdown-links": "0.9.0",

--- a/test/fixtures/base-typescript/named-reference-shapes.ts
+++ b/test/fixtures/base-typescript/named-reference-shapes.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/no-extraneous-class, restricted-syntax/no-class-declaration, @typescript-eslint/no-unused-vars, restricted-syntax/no-empty-function-body, @typescript-eslint/explicit-function-return-type */
+
+// Named-reference-shaped parameter types and type-alias right-hand sides must
+// be accepted regardless of how the reference is expressed: `typeof X`,
+// `keyof typeof X`, a union of named references, or a built-in utility-type
+// composition over named references. Inline structural mutable types must
+// still be flagged. Lowercase-namespaced type queries such as
+// `ns.member<typeof x>` (e.g. `z.infer<typeof schema>`) are intentionally
+// NOT covered by the ignore pattern — when the inferred type resolves to a
+// mutable shape the rule must still flag it.
+
+declare class InMemoryApp {
+    public name: string;
+    public synth(): void;
+}
+
+declare class Http2SecureServer {
+    public listen(): void;
+}
+
+declare class Http2Server {
+    public listen(): void;
+}
+
+declare class TcpServer {
+    public listen(): void;
+}
+
+declare class Uploader {
+    public upload(input: string): Promise<{ ok: boolean }>;
+}
+
+declare const mutableInferenceSource: { parse(value: unknown): { value: string } };
+
+declare namespace inferenceNamespace {
+    export type infer<TSchema> = TSchema extends { parse(value: unknown): infer TInferred } ? TInferred : never;
+}
+
+// Valid: named-reference-shaped parameter types must be accepted.
+export declare function takeTypeofClass(value: typeof InMemoryApp): void;
+export declare function takeKeyofTypeofClass(value: keyof typeof InMemoryApp): void;
+export declare function takeNamedUnion(value: Http2SecureServer | Http2Server | TcpServer): void;
+export declare function takeUtilityWrapped(value: Awaited<ReturnType<Uploader['upload']>>): void;
+
+// Invalid: lowercase-namespaced inferred types must still be flagged when the
+// resolved shape is mutable.
+export declare function takeMutableInference(value: inferenceNamespace.infer<typeof mutableInferenceSource>): void;
+
+// Invalid: inline structural mutable parameter types must still be flagged.
+export declare function takeInlineObject(value: { name: string; count: number }): void;
+export declare function takeArrayLiteral(value: string[]): void;
+
+// Valid: named-reference-shaped type aliases must be accepted.
+export type UnderlyingServer = Http2SecureServer | Http2Server | TcpServer;
+export type UploadResult = Awaited<ReturnType<Uploader['upload']>>;
+export type AppConstructor = typeof InMemoryApp;
+export type AppKey = keyof typeof InMemoryApp;
+
+// Invalid: lowercase-namespaced inferred alias must still be flagged when the
+// resolved shape is mutable.
+export type MutableInferred = inferenceNamespace.infer<typeof mutableInferenceSource>;
+
+// Invalid: inline structural mutable aliases must still be flagged (and the
+// fixer keeps rewriting them).
+export type InlineObjectAlias = { name: string; count: number };
+export type ArrayAlias = string[];

--- a/test/integration/base-typescript.test.js
+++ b/test/integration/base-typescript.test.js
@@ -171,4 +171,68 @@ suite('base+typescript integration', function () {
             'inline mutable parameter types must still be flagged'
         );
     });
+
+    test('base+typescript named-reference-shaped parameters (typeof, unions, utility wrappers) are accepted while inferred mutable types stay flagged', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'named-reference-shapes.ts');
+        const flaggedLines = new Set(
+            messages
+                .filter((message) => {
+                    return message.ruleId === 'functional/prefer-immutable-types';
+                })
+                .map((message) => {
+                    return message.line;
+                })
+        );
+        const acceptedNamedReferenceLines = new Set([ 40, 41, 42, 43 ]);
+        const expectedFlaggedLines = new Set([ 47, 50, 51 ]);
+        const unexpectedNamedReferenceReports = Array.from(acceptedNamedReferenceLines).filter(
+            (line) => {
+                return flaggedLines.has(line);
+            }
+        );
+        const missingFlaggedReports = Array.from(expectedFlaggedLines).filter((line) => {
+            return !flaggedLines.has(line);
+        });
+        assert.deepStrictEqual(
+            unexpectedNamedReferenceReports,
+            [],
+            'named-reference-shaped parameter types must not be flagged'
+        );
+        assert.deepStrictEqual(
+            missingFlaggedReports,
+            [],
+            'lowercase-namespaced inferred mutable types and inline mutable types must still be flagged'
+        );
+    });
+
+    test('base+typescript named-reference-shaped type aliases are accepted while inline structural aliases stay flagged', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'named-reference-shapes.ts');
+        const flaggedLines = new Set(
+            messages
+                .filter((message) => {
+                    return message.ruleId === 'functional/type-declaration-immutability';
+                })
+                .map((message) => {
+                    return message.line;
+                })
+        );
+        const acceptedAliasLines = new Set([ 54, 55, 56, 57 ]);
+        const expectedFlaggedAliasLines = new Set([ 61, 65, 66 ]);
+        const unexpectedAliasReports = Array.from(acceptedAliasLines).filter((line) => {
+            return flaggedLines.has(line);
+        });
+        const missingAliasReports = Array.from(expectedFlaggedAliasLines).filter((line) => {
+            return !flaggedLines.has(line);
+        });
+        assert.deepStrictEqual(
+            unexpectedAliasReports,
+            [],
+            'named-reference-shaped type aliases must not be flagged'
+        );
+        assert.deepStrictEqual(
+            missingAliasReports,
+            [],
+            'lowercase-namespaced inferred mutable aliases and inline mutable aliases must still be flagged'
+        );
+    });
 });


### PR DESCRIPTION
Extends the shared named-reference ignore pattern beyond bare PascalCase to cover `typeof X`, `keyof typeof X`, unions and intersections of named references, and utility-type compositions such as `Awaited<...>` and `ReturnType<...>`.

Applies the same pattern to `functional/type-declaration-immutability` via the `ignoreTypePattern` option that landed in `eslint-plugin-functional@10`, so alias right-hand sides like `Http2SecureServer | Http2Server | Server` and `Awaited<ReturnType<Uploader['upload']>>` are accepted alongside the parameter forms.

Lowercase-namespaced inferred forms such as `z.infer<typeof schema>` stay outside the pattern on purpose — when the inferred shape is mutable the rule must still flag it. A new fixture plus two tests cover both rules and the negative cases.
