### PR TITLE
Add `eslint-plugin-regexp` to base best-practices rule set

### DIFF
--- a/configs/rule-sets/best-practices.js
+++ b/configs/rule-sets/best-practices.js
@@ -1,6 +1,7 @@
 import arrayFunctionPlugin from 'eslint-plugin-array-func';
 import noBarrelFiles from 'eslint-plugin-no-barrel-files';
 import promisePlugin from 'eslint-plugin-promise';
+import * as regexpPlugin from 'eslint-plugin-regexp';
 import sonarjsPlugin from 'eslint-plugin-sonarjs';
 import unicornPlugin from 'eslint-plugin-unicorn';
 
@@ -33,7 +34,8 @@ export const bestPracticesRuleSet = {
         promise: promisePlugin,
         'array-func': arrayFunctionPlugin,
         sonarjs: sonarjsPlugin,
-        'no-barrel-files': noBarrelFiles
+        'no-barrel-files': noBarrelFiles,
+        regexp: regexpPlugin
     },
     settings: {},
     rules: {
@@ -226,6 +228,9 @@ export const bestPracticesRuleSet = {
         'sonarjs/prefer-object-literal': 'error',
         'sonarjs/prefer-single-boolean-return': 'error',
         'sonarjs/prefer-while': 'error',
+        // regexp/no-super-linear-backtracking subsumes this with a sound NFA-based analysis
+        // (sonarjs is heuristic); see the regexp/* block below.
+        'sonarjs/slow-regex': 'off',
 
         'promise/avoid-new': 'off',
         'promise/no-nesting': 'error',
@@ -250,6 +255,97 @@ export const bestPracticesRuleSet = {
         'promise/spec-only': 'error',
         'promise/prefer-catch': 'error',
 
-        'no-barrel-files/no-barrel-files': 'error'
+        'no-barrel-files/no-barrel-files': 'error',
+
+        // eslint-plugin-regexp — purely additive on top of core / unicorn / sonarjs regex coverage.
+        // Rules with a working equivalent already in core, unicorn, or sonarjs are turned off here so
+        // each diagnostic is reported by exactly one rule. The only swap is regexp/no-super-linear-backtracking
+        // taking over from the (off-above) sonarjs/slow-regex.
+        'regexp/confusing-quantifier': 'error',
+        'regexp/control-character-escape': 'error',
+        'regexp/match-any': 'error',
+        'regexp/negation': 'error',
+        'regexp/no-contradiction-with-assertion': 'error',
+        'regexp/no-dupe-disjunctions': 'error',
+        'regexp/no-empty-capturing-group': 'error',
+        'regexp/no-empty-group': 'error',
+        'regexp/no-empty-lookarounds-assertion': 'error',
+        'regexp/no-empty-string-literal': 'error',
+        'regexp/no-escape-backspace': 'error',
+        'regexp/no-extra-lookaround-assertions': 'error',
+        'regexp/no-invisible-character': 'error',
+        'regexp/no-lazy-ends': 'error',
+        'regexp/no-legacy-features': 'error',
+        'regexp/no-misleading-capturing-group': 'error',
+        'regexp/no-missing-g-flag': 'error',
+        'regexp/no-non-standard-flag': 'error',
+        'regexp/no-obscure-range': 'error',
+        'regexp/no-octal': 'error',
+        'regexp/no-optional-assertion': 'error',
+        'regexp/no-potentially-useless-backreference': 'error',
+        'regexp/no-standalone-backslash': 'error',
+        'regexp/no-super-linear-backtracking': 'error',
+        'regexp/no-super-linear-move': 'error',
+        'regexp/no-trivially-nested-assertion': 'error',
+        'regexp/no-trivially-nested-quantifier': 'error',
+        'regexp/no-unused-capturing-group': 'error',
+        'regexp/no-useless-assertions': 'error',
+        'regexp/no-useless-character-class': 'error',
+        'regexp/no-useless-dollar-replacements': 'error',
+        'regexp/no-useless-flag': 'error',
+        'regexp/no-useless-lazy': 'error',
+        'regexp/no-useless-non-capturing-group': 'error',
+        'regexp/no-useless-quantifier': 'error',
+        'regexp/no-useless-range': 'error',
+        'regexp/no-useless-set-operand': 'error',
+        'regexp/no-useless-string-literal': 'error',
+        'regexp/no-useless-two-nums-quantifier': 'error',
+        'regexp/no-zero-quantifier': 'error',
+        'regexp/optimal-lookaround-quantifier': 'error',
+        'regexp/optimal-quantifier-concatenation': 'error',
+        'regexp/prefer-escape-replacement-dollar-char': 'error',
+        'regexp/prefer-named-backreference': 'error',
+        'regexp/prefer-named-replacement': 'error',
+        'regexp/prefer-result-array-groups': 'error',
+        'regexp/prefer-set-operation': 'error',
+        'regexp/prefer-unicode-codepoint-escapes': 'error',
+        'regexp/simplify-set-operations': 'error',
+
+        // Overlap with existing rules — keep the existing rule as single source of truth.
+        'regexp/no-control-character': 'off', // core no-control-regex
+        'regexp/no-dupe-characters-character-class': 'off', // sonarjs/duplicates-in-character-class
+        'regexp/no-empty-alternative': 'off', // sonarjs/no-empty-alternatives
+        'regexp/no-empty-character-class': 'off', // core no-empty-character-class
+        'regexp/no-invalid-regexp': 'off', // core no-invalid-regexp
+        'regexp/no-misleading-unicode-character': 'off', // core no-misleading-character-class
+        'regexp/no-useless-backreference': 'off', // core no-useless-backreference
+        'regexp/no-useless-escape': 'off', // core no-useless-escape
+        'regexp/prefer-character-class': 'off', // unicorn/better-regex + sonarjs/concise-regex
+        'regexp/prefer-d': 'off', // unicorn/better-regex
+        'regexp/prefer-named-capture-group': 'off', // core prefer-named-capture-group
+        'regexp/prefer-plus-quantifier': 'off', // unicorn/better-regex
+        'regexp/prefer-question-quantifier': 'off', // unicorn/better-regex
+        'regexp/prefer-regexp-exec': 'off', // @typescript-eslint/prefer-regexp-exec
+        'regexp/prefer-regexp-test': 'off', // unicorn/prefer-regexp-test
+        'regexp/prefer-star-quantifier': 'off', // unicorn/better-regex
+        'regexp/prefer-w': 'off', // unicorn/better-regex
+        'regexp/require-unicode-regexp': 'off', // matches core require-unicode-regexp (off)
+        'regexp/strict': 'off', // unicorn/better-regex
+
+        // Pure style preferences outside the project's scope.
+        'regexp/grapheme-string-literal': 'off',
+        'regexp/hexadecimal-escape': 'off',
+        'regexp/letter-case': 'off',
+        'regexp/prefer-lookaround': 'off',
+        'regexp/prefer-predefined-assertion': 'off',
+        'regexp/prefer-quantifier': 'off',
+        'regexp/prefer-range': 'off',
+        'regexp/require-unicode-sets-regexp': 'off',
+        'regexp/sort-alternatives': 'off',
+        'regexp/sort-character-class-elements': 'off',
+        'regexp/sort-flags': 'off',
+        'regexp/unicode-escape': 'off',
+        'regexp/unicode-property': 'off',
+        'regexp/use-ignore-case': 'off'
     }
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,8 @@ const codeSpellCheckerRules = {
                     'mdast',
                     'autolinks',
                     'blockquotes',
-                    'setext'
+                    'setext',
+                    'lookarounds'
                 ]
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
                 "eslint-plugin-promise": "7.3.0",
                 "eslint-plugin-react": "7.37.5",
                 "eslint-plugin-react-hooks": "7.1.1",
+                "eslint-plugin-regexp": "3.1.0",
                 "eslint-plugin-sonarjs": "4.0.3",
                 "eslint-plugin-unicorn": "64.0.0",
                 "eslint-plugin-vue": "10.9.2",
@@ -5637,6 +5638,27 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/eslint-plugin-regexp": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-3.1.0.tgz",
+            "integrity": "sha512-qGXIC3DIKZHcK1H9A9+Byz9gmndY6TTSRkSMTZpNXdyCw2ObSehRgccJv35n9AdUakEjQp5VFNLas6BMXizCZg==",
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.11.0",
+                "comment-parser": "^1.4.0",
+                "jsdoc-type-pratt-parser": "^7.0.0",
+                "refa": "^0.12.1",
+                "regexp-ast-analysis": "^0.7.1",
+                "scslre": "^0.3.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "peerDependencies": {
+                "eslint": ">=9.38.0"
+            }
+        },
         "node_modules/eslint-plugin-sonarjs": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
@@ -7549,6 +7571,15 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsdoc-type-pratt-parser": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+            "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/jsesc": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "eslint-plugin-promise": "7.3.0",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "7.1.1",
+        "eslint-plugin-regexp": "3.1.0",
         "eslint-plugin-sonarjs": "4.0.3",
         "eslint-plugin-unicorn": "64.0.0",
         "eslint-plugin-vue": "10.9.2",

--- a/test/base-with-prettier-plugin-rule-set.js
+++ b/test/base-with-prettier-plugin-rule-set.js
@@ -1,0 +1,19 @@
+import { rules as eslintCommentsPluginRules } from '@eslint-community/eslint-plugin-eslint-comments';
+import markdownPlugin from '@eslint/markdown';
+import { rules as importPluginRules } from 'eslint-plugin-import-x';
+import { rules as markdownLinksPluginRules } from 'eslint-plugin-markdown-links';
+import { rules as markdownPreferencesPluginRules } from 'eslint-plugin-markdown-preferences';
+import { rules as noSecretsPluginRules } from 'eslint-plugin-no-secrets';
+import prettierPlugin from 'eslint-plugin-prettier';
+import { rules as regexpPluginRules } from 'eslint-plugin-regexp';
+
+export const baseWithPrettierPluginRuleSet = {
+    'eslint-plugin-no-secrets': noSecretsPluginRules,
+    'eslint-plugin-import': importPluginRules,
+    'eslint-plugin-eslint-comments': eslintCommentsPluginRules,
+    'eslint-plugin-prettier': prettierPlugin.rules,
+    '@eslint/markdown': markdownPlugin.rules,
+    'eslint-plugin-markdown-links': markdownLinksPluginRules,
+    'eslint-plugin-markdown-preferences': markdownPreferencesPluginRules,
+    'eslint-plugin-regexp': regexpPluginRules
+};

--- a/test/base-with-prettier.test.js
+++ b/test/base-with-prettier.test.js
@@ -1,12 +1,6 @@
-import { rules as eslintCommentsPluginRules } from '@eslint-community/eslint-plugin-eslint-comments';
-import markdownPlugin from '@eslint/markdown';
 import { suite, test } from 'mocha';
-import { rules as importPluginRules } from 'eslint-plugin-import-x';
-import { rules as markdownLinksPluginRules } from 'eslint-plugin-markdown-links';
-import { rules as markdownPreferencesPluginRules } from 'eslint-plugin-markdown-preferences';
-import { rules as noSecretsPluginRules } from 'eslint-plugin-no-secrets';
-import prettierPlugin from 'eslint-plugin-prettier';
 import { baseWithPrettierConfig } from '../configs/presets/base-with-prettier/base-with-prettier.js';
+import { baseWithPrettierPluginRuleSet } from './base-with-prettier-plugin-rule-set.js';
 import {
     checkAllCoreRulesConfigured,
     checkAllPluginRulesConfigured,
@@ -47,13 +41,9 @@ suite('base-with-prettier preset', function () {
         checkUnknownCoreRulesAreNotConfigured({ ruleConfigSet: baseWithPrettierConfigRules });
     });
 
-    pluginCoverageSuite('eslint-plugin-no-secrets', noSecretsPluginRules);
-    pluginCoverageSuite('eslint-plugin-import', importPluginRules);
-    pluginCoverageSuite('eslint-plugin-eslint-comments', eslintCommentsPluginRules);
-    pluginCoverageSuite('eslint-plugin-prettier', prettierPlugin.rules);
-    pluginCoverageSuite('@eslint/markdown', markdownPlugin.rules);
-    pluginCoverageSuite('eslint-plugin-markdown-links', markdownLinksPluginRules);
-    pluginCoverageSuite('eslint-plugin-markdown-preferences', markdownPreferencesPluginRules);
+    for (const [ pluginName, pluginRules ] of Object.entries(baseWithPrettierPluginRuleSet)) {
+        pluginCoverageSuite(pluginName, pluginRules);
+    }
 
     test('base-with-prettier preset config has no validation errors', function () {
         checkConfigToHaveNoValidationIssues(baseWithPrettierConfig);

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -5,6 +5,7 @@ import { rules as importPluginRules } from 'eslint-plugin-import-x';
 import { rules as markdownLinksPluginRules } from 'eslint-plugin-markdown-links';
 import { rules as markdownPreferencesPluginRules } from 'eslint-plugin-markdown-preferences';
 import { rules as noSecretsPluginRules } from 'eslint-plugin-no-secrets';
+import { rules as regexpPluginRules } from 'eslint-plugin-regexp';
 import { baseConfig } from '../configs/presets/base/base.js';
 import {
     checkAllCoreRulesConfigured,
@@ -44,6 +45,7 @@ suite('base preset', function () {
     pluginCoverageSuite('@eslint/markdown', markdownPlugin.rules);
     pluginCoverageSuite('eslint-plugin-markdown-links', markdownLinksPluginRules);
     pluginCoverageSuite('eslint-plugin-markdown-preferences', markdownPreferencesPluginRules);
+    pluginCoverageSuite('eslint-plugin-regexp', regexpPluginRules);
 
     test('base preset config has no validation errors', function () {
         checkConfigToHaveNoValidationIssues(baseConfig);


### PR DESCRIPTION
Pulls in the 82-rule [`eslint-plugin-regexp`](https://github.com/ota-meshi/eslint-plugin-regexp) as a purely additive layer on top of the existing core / unicorn / sonarjs regex coverage. Every regexp rule that has a working equivalent in those is turned off here so each diagnostic fires from exactly one rule.

The only swap is `regexp/no-super-linear-backtracking` taking over from `sonarjs/slow-regex` (also turned off in the same file): the regexp version uses a sound NFA-based analysis, the sonarjs one is heuristic.

The net new coverage focuses on correctness — catastrophic backtracking and quadratic moves, dead branches (`no-dupe-disjunctions`, `no-empty-group`, `no-empty-lookarounds-assertion`, `no-zero-quantifier`), assertion contradictions, misleading capturing groups, lazy quantifiers that can never match lazily (`no-lazy-ends`), missing `g` flags on `matchAll`, and a number of subtle escape and character-class footguns. Stylistic regexp rules and rules that overlap with `unicorn/better-regex`'s autofixer are left off.

The `base-with-prettier` test file crossed `import/max-dependencies` and `max-statements` once the new coverage suite was added, so its plugin rule set is extracted into `test/base-with-prettier-plugin-rule-set.js` and the per-suite registration is collapsed into a loop.
