### PR TITLE
Fix `main` CI by converting arrow callbacks in tests to function expressions

### DIFF
--- a/test/eslint-plugin.test.js
+++ b/test/eslint-plugin.test.js
@@ -52,7 +52,7 @@ suite('eslint-plugin preset', function () {
 
     test('throws when docsUrlPattern does not contain the {{name}} placeholder', function () {
         assert.throws(
-            () => {
+            function createWithInvalidDocsUrlPattern() {
                 return createEslintPluginConfig({
                     docsUrlPattern: 'https://example.com/rules/foo.md',
                     descriptionPattern: sampleDescriptionPattern
@@ -64,7 +64,7 @@ suite('eslint-plugin preset', function () {
 
     test('throws when docsUrlPattern is not a string', function () {
         assert.throws(
-            () => {
+            function createWithMissingDocsUrlPattern() {
                 return createEslintPluginConfig({
                     docsUrlPattern: undefined,
                     descriptionPattern: sampleDescriptionPattern
@@ -76,7 +76,7 @@ suite('eslint-plugin preset', function () {
 
     test('throws when descriptionPattern is not a string', function () {
         assert.throws(
-            () => {
+            function createWithMissingDescriptionPattern() {
                 return createEslintPluginConfig({
                     docsUrlPattern: sampleDocsUrlPattern,
                     descriptionPattern: undefined

--- a/test/integration/base-typescript.test.js
+++ b/test/integration/base-typescript.test.js
@@ -181,21 +181,21 @@ suite('base+typescript integration', function () {
         const { messages } = await lintFixture(configs, comboName, 'named-reference-shapes.ts');
         const flaggedLines = new Set(
             messages
-                .filter((message) => {
+                .filter(function isImmutableTypesMessage(message) {
                     return message.ruleId === 'functional/prefer-immutable-types';
                 })
-                .map((message) => {
+                .map(function toLine(message) {
                     return message.line;
                 })
         );
         const acceptedNamedReferenceLines = new Set([ 40, 41, 42, 43 ]);
         const expectedFlaggedLines = new Set([ 47, 50, 51 ]);
         const unexpectedNamedReferenceReports = Array.from(acceptedNamedReferenceLines).filter(
-            (line) => {
+            function isFlagged(line) {
                 return flaggedLines.has(line);
             }
         );
-        const missingFlaggedReports = Array.from(expectedFlaggedLines).filter((line) => {
+        const missingFlaggedReports = Array.from(expectedFlaggedLines).filter(function isNotFlagged(line) {
             return !flaggedLines.has(line);
         });
         assert.deepStrictEqual(
@@ -214,19 +214,19 @@ suite('base+typescript integration', function () {
         const { messages } = await lintFixture(configs, comboName, 'named-reference-shapes.ts');
         const flaggedLines = new Set(
             messages
-                .filter((message) => {
+                .filter(function isTypeImmutabilityMessage(message) {
                     return message.ruleId === 'functional/type-declaration-immutability';
                 })
-                .map((message) => {
+                .map(function toLine(message) {
                     return message.line;
                 })
         );
         const acceptedAliasLines = new Set([ 54, 55, 56, 57 ]);
         const expectedFlaggedAliasLines = new Set([ 61, 65, 66 ]);
-        const unexpectedAliasReports = Array.from(acceptedAliasLines).filter((line) => {
+        const unexpectedAliasReports = Array.from(acceptedAliasLines).filter(function isFlagged(line) {
             return flaggedLines.has(line);
         });
-        const missingAliasReports = Array.from(expectedFlaggedAliasLines).filter((line) => {
+        const missingAliasReports = Array.from(expectedFlaggedAliasLines).filter(function isNotFlagged(line) {
             return !flaggedLines.has(line);
         });
         assert.deepStrictEqual(


### PR DESCRIPTION
PR #730 added the `restricted-syntax/no-unnecessary-arrow-function` rule and merged in parallel with PRs that introduced new arrow callbacks in `test/eslint-plugin.test.js` and `test/integration/base-typescript.test.js`. Because neither PR was rebased on the other, `main` now fails CI under Node.js v24 and v26.

The fix converts the offending arrows to the named-function expression style already used elsewhere in those files, so the surrounding test logic stays unchanged.