### PR TITLE
Add tslib dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
                 "eslint-plugin-vue": "10.9.2",
                 "globals": "17.6.0",
                 "jsonc-eslint-parser": "3.1.0",
+                "tslib": "2.8.1",
                 "vue-eslint-parser": "10.4.1"
             },
             "devDependencies": {
@@ -12632,8 +12633,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "optional": true
+            "license": "0BSD"
         },
         "node_modules/tuf-js": {
             "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "eslint-plugin-vue": "10.9.2",
         "globals": "17.6.0",
         "jsonc-eslint-parser": "3.1.0",
+        "tslib": "2.8.1",
         "vue-eslint-parser": "10.4.1"
     },
     "devDependencies": {


### PR DESCRIPTION
https://github.com/enormora/eslint-config/pull/740 migrated from JavaScript to TypeScript and [enabled](https://github.com/enormora/eslint-config/blob/383f1a4067ce9ac6111f1828bfc9342f6f7c38b5/tsconfig.base.json#L16) `importHelpers`. But they rely on (missing) `tslib` dependency.