### PR TITLE
Compile sources before publishing in the `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
             - name: Publish packages
               id: publish-packages
               continue-on-error: true
-              run: npx packtory publish --no-dry-run
+              run: npx just packtory-publish
             # The `sigstore` wrapper used by `libnpmpublish` hardcodes
             # `fetchOnConflict: false`, so a retried Rekor POST after a
             # transient blip surfaces as
@@ -94,4 +94,4 @@ jobs:
               if: steps.publish-packages.outcome == 'failure'
               run: |
                   sleep 10
-                  npx packtory publish --no-dry-run
+                  npx just packtory-publish

--- a/justfile
+++ b/justfile
@@ -21,3 +21,6 @@ test: compile
 
 packtory-dry-run: compile
     packtory publish
+
+packtory-publish: compile
+    packtory publish --no-dry-run


### PR DESCRIPTION
The publish workflow invoked `npx packtory publish --no-dry-run` directly, bypassing the `just` recipes that own `tsc --build`. After the JS->TS migration, `@packtory/cli` reads from `target/build/configs`, which only exists after compilation, so the workflow had nothing to publish while CI stayed green (CI uses `npx just packtory-dry-run`, which depends on `compile`).

Adds a `packtory-publish` recipe mirroring `packtory-dry-run` and routes both the initial publish step and the sigstore retry through `npx just packtory-publish`.
