### PR TITLE
Compile sources before evaluating the release gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
               run: npm clean-install --ignore-scripts
             - name: Evaluate GitHub release gate
               id: release-gate
-              run: npx github-release-gate
+              run: npx just release-gate
               env:
                   CI_WORKFLOW_FILE: continuous-integration.yml
                   DEFAULT_BRANCH: main

--- a/justfile
+++ b/justfile
@@ -24,3 +24,6 @@ packtory-dry-run: compile
 
 packtory-publish: compile
     packtory publish --no-dry-run
+
+release-gate: compile
+    github-release-gate


### PR DESCRIPTION
PR #749 fixed the compile prerequisite for the `publish` job but left a second one in the `evaluate-gate` job. The gate calls `npx github-release-gate`, which loads `packtory.config.js` once it decides publishing should proceed; the config references `target/build/configs/...`, which only exists after `tsc --build`. Earlier scheduled runs masked it by short-circuiting on `activity_not_stale`; the failure surfaced as soon as the gate actually voted to publish.

Adds a `release-gate` recipe that depends on `compile` and routes the workflow step through `npx just release-gate`, mirroring the `packtory-publish` recipe.
