### PR TITLE
Allow GFM task-list checkbox markers in `markdown/no-missing-label-refs`

### DIFF
--- a/configs/presets/base/markdown-lint-rules.ts
+++ b/configs/presets/base/markdown-lint-rules.ts
@@ -22,7 +22,10 @@ export const markdownLintRules = {
     'markdown/no-html': 'error',
     'markdown/no-invalid-label-refs': 'error',
     'markdown/no-missing-atx-heading-space': 'error',
-    'markdown/no-missing-label-refs': 'error',
+    // Allow the three GFM task-list checkbox markers (`[ ]`, `[x]`, `[X]`). The commonmark
+    // language has no concept of task lists, so the rule otherwise reports the checkbox content
+    // as a missing label reference.
+    'markdown/no-missing-label-refs': [ 'error', { allowLabels: [ '', 'x', 'X' ] } ],
     'markdown/no-missing-link-fragments': 'error',
     'markdown/no-multiple-h1': 'error',
     'markdown/no-reference-like-urls': 'error',

--- a/test/fixtures/base-markdown/clean.md
+++ b/test/fixtures/base-markdown/clean.md
@@ -20,3 +20,9 @@ const answer = 42;
 | value 3  | value 4  |
 
 See the [reference](https://example.com/ref) for more details.
+
+GFM task-list checkboxes should not be flagged as missing label references:
+
+- [ ] open task
+- [x] completed task
+- plain list item without a checkbox


### PR DESCRIPTION
GFM task-list checkboxes such as `- [ ] task` and `- [x] done` triggered `markdown/no-missing-label-refs` because the base preset is pinned to `markdown/commonmark`, which parses `[ ]` and `[x]` as reference-style link labels.

Rather than disabling the rule or switching to `markdown/gfm` (still blocked upstream by the `getLoc()` crash in `@eslint/markdown@8.0.2` for `no-bare-urls` and `table-column-count`), this configures the rule's documented `allowLabels` option with the three GFM checkbox marker spellings (`''`, `'x'`, `'X'`). `'X'` is included even though dprint normalizes it to lowercase, so consumers see a capitalization fix instead of a spurious missing-label report.
