### PR TITLE
Disable `markdown-preferences/prefer-autolinks`

### DIFF
--- a/configs/presets/base/markdown-lint-rules.ts
+++ b/configs/presets/base/markdown-lint-rules.ts
@@ -43,9 +43,14 @@ export const markdownLintRules = {
     'markdown-links/no-self-destination': 'error',
 
     // markdown-preferences: many rules overlap with the active markdown formatter (dprint or
-    // prettier, depending on which base preset is used). We enable only the 8 rules from this
+    // prettier, depending on which base preset is used). We enable only 7 rules from this
     // plugin's `recommended` config (none of which fight either formatter) and explicitly turn
-    // the other 45 off. Override individually if a stricter style is desired.
+    // the other 46 off. Override individually if a stricter style is desired.
+    //
+    // `prefer-autolinks` is intentionally disabled even though it is in `recommended`: its
+    // autofix rewrites any `[x](x)` to `<x>` without checking whether the URL has a scheme.
+    // CommonMark autolinks require an absolute URI, so a relative link like `[foo.md](foo.md)`
+    // becomes `<foo.md>`, which GitHub renders as an empty HTML tag (the link disappears).
     'markdown-preferences/atx-heading-closing-sequence': 'off',
     'markdown-preferences/atx-heading-closing-sequence-length': 'off',
     'markdown-preferences/blockquote-marker-alignment': 'error',
@@ -84,7 +89,7 @@ export const markdownLintRules = {
     'markdown-preferences/ordered-list-marker-style': 'off',
     'markdown-preferences/padded-custom-containers': 'off',
     'markdown-preferences/padding-line-between-blocks': 'off',
-    'markdown-preferences/prefer-autolinks': 'error',
+    'markdown-preferences/prefer-autolinks': 'off',
     'markdown-preferences/prefer-fenced-code-blocks': 'error',
     'markdown-preferences/prefer-inline-code-words': 'off',
     'markdown-preferences/prefer-link-reference-definitions': 'off',

--- a/test/integration/base-markdown.test.ts
+++ b/test/integration/base-markdown.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert';
+import path from 'node:path';
+import { Linter } from 'eslint';
 import { suite, test } from 'mocha';
 import { baseConfig } from '../../configs/presets/base/base.ts';
 import { fixFixture, lintFixture, resolveFixture, uniqueSortedRuleIds } from './lint-fixture.ts';
@@ -58,5 +60,25 @@ suite('base markdown integration', function () {
         const secondPass = fixFixture(configs, firstPass.output, filePath);
         assert.strictEqual(secondPass.output, firstPass.output, 'second autofix pass changed the output');
         assert.strictEqual(secondPass.fixed, false, 'second autofix pass reported further fixes');
+    });
+
+    test('autofix does not rewrite [text](text) markdown links to <text> autolinks', function () {
+        const filePath = path.join(process.cwd(), 'test/fixtures/base-markdown/regression-prefer-autolinks.md');
+        const source = '# regression\n\n[foo.md](foo.md)\n';
+        const linter = new Linter({ configType: 'flat' });
+        const messages = linter.verify(source, configs, filePath);
+        const preferAutolinkMessages = messages.filter(function isPreferAutolinkMessage(message) {
+            return message.ruleId === 'markdown-preferences/prefer-autolinks';
+        });
+        assert.deepStrictEqual(
+            preferAutolinkMessages,
+            [],
+            'markdown-preferences/prefer-autolinks must stay disabled in the base preset'
+        );
+        const fixResult = linter.verifyAndFix(source, configs, { filename: filePath });
+        assert.ok(
+            !fixResult.output.includes('<foo.md>'),
+            'autofix must not rewrite [foo.md](foo.md) to the invalid CommonMark autolink <foo.md>'
+        );
     });
 });


### PR DESCRIPTION
The rule's autofix rewrites any `[x](x)` inline link to `<x>` whenever the link text equals the URL, with no scheme check. CommonMark autolinks require an absolute URI, so a relative link like `[foo.md](foo.md)` becomes `<foo.md>`, which GitHub renders as an empty HTML tag and the link disappears from the rendered output.

An integration regression test asserts the rule stays off in the base preset and the autofix does not rewrite such links.
