### PR TITLE
Replace `@ben_12/eslint-simple-parser` with an in-repo plain-text language plugin

### DIFF
--- a/configs/presets/base-with-prettier/base-with-prettier.ts
+++ b/configs/presets/base-with-prettier/base-with-prettier.ts
@@ -1,9 +1,9 @@
-import simpleParser from '@ben_12/eslint-simple-parser';
 import type { Linter } from 'eslint';
 import prettierPlugin from 'eslint-plugin-prettier';
 import { baseSharedConfig } from '../base/base-shared.ts';
 import { markdownLintPlugins, markdownLintRules } from '../base/markdown-lint-rules.ts';
 import { packageJsonConfig } from '../base/package-json.ts';
+import { plainTextLanguagePlugin } from '../base/plain-text-language.ts';
 
 const baseJsConfig = {
     files: [ '**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,vue}' ],
@@ -24,15 +24,22 @@ const baseJsConfig = {
 
 const prettierJsonConfig = {
     files: [ '**/*.json' ],
-    languageOptions: { parser: simpleParser },
+    ignores: [ '**/package.json' ],
+    language: 'plain-text/any',
+    plugins: { 'plain-text': plainTextLanguagePlugin, prettier: prettierPlugin },
+    rules: { 'prettier/prettier': 'error' }
+};
+
+const prettierPackageJsonConfig = {
+    files: [ '**/package.json' ],
     plugins: { prettier: prettierPlugin },
     rules: { 'prettier/prettier': 'error' }
 };
 
 const prettierYamlConfig = {
     files: [ '**/*.{yml,yaml}' ],
-    languageOptions: { parser: simpleParser },
-    plugins: { prettier: prettierPlugin },
+    language: 'plain-text/any',
+    plugins: { 'plain-text': plainTextLanguagePlugin, prettier: prettierPlugin },
     rules: { 'prettier/prettier': 'error' }
 };
 
@@ -55,6 +62,7 @@ export const baseWithPrettierConfig = [
     baseJsConfig,
     prettierJsonConfig,
     packageJsonConfig,
+    prettierPackageJsonConfig,
     markdownConfig,
     prettierYamlConfig
 ] as unknown as Linter.Config[];

--- a/configs/presets/base/base.ts
+++ b/configs/presets/base/base.ts
@@ -1,11 +1,11 @@
 import dprintPlugin from '@ben_12/eslint-plugin-dprint';
-import simpleParser from '@ben_12/eslint-simple-parser';
 import type { Linter } from 'eslint';
 import { baseSharedConfig } from './base-shared.ts';
 import { jsonDprintConfig, tomlDprintConfig, typescriptDprintConfig, yamlDprintConfig } from './dprint-config.ts';
 import { dprintSettings } from './dprint-formatters.ts';
 import { markdownConfig } from './markdown.ts';
 import { packageJsonConfig } from './package-json.ts';
+import { plainTextLanguagePlugin } from './plain-text-language.ts';
 
 const baseJsConfig = {
     files: [ '**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,vue}' ],
@@ -34,7 +34,15 @@ const baseJsConfig = {
 
 const dprintJsonConfig = {
     files: [ '**/*.json' ],
-    languageOptions: { parser: simpleParser },
+    ignores: [ '**/package.json' ],
+    language: 'plain-text/any',
+    plugins: { 'plain-text': plainTextLanguagePlugin, dprint: dprintPlugin },
+    settings: dprintSettings,
+    rules: { 'dprint/json': [ 'error', { config: jsonDprintConfig } ] }
+};
+
+const dprintPackageJsonConfig = {
+    files: [ '**/package.json' ],
     plugins: { dprint: dprintPlugin },
     settings: dprintSettings,
     rules: { 'dprint/json': [ 'error', { config: jsonDprintConfig } ] }
@@ -42,16 +50,16 @@ const dprintJsonConfig = {
 
 const dprintYamlConfig = {
     files: [ '**/*.{yml,yaml}' ],
-    languageOptions: { parser: simpleParser },
-    plugins: { dprint: dprintPlugin },
+    language: 'plain-text/any',
+    plugins: { 'plain-text': plainTextLanguagePlugin, dprint: dprintPlugin },
     settings: dprintSettings,
     rules: { 'dprint/yaml': [ 'error', { config: yamlDprintConfig } ] }
 };
 
 const dprintTomlConfig = {
     files: [ '**/*.toml' ],
-    languageOptions: { parser: simpleParser },
-    plugins: { dprint: dprintPlugin },
+    language: 'plain-text/any',
+    plugins: { 'plain-text': plainTextLanguagePlugin, dprint: dprintPlugin },
     settings: dprintSettings,
     rules: { 'dprint/toml': [ 'error', { config: tomlDprintConfig } ] }
 };
@@ -60,6 +68,7 @@ export const baseConfig = [
     baseJsConfig,
     dprintJsonConfig,
     packageJsonConfig,
+    dprintPackageJsonConfig,
     markdownConfig,
     dprintYamlConfig,
     dprintTomlConfig

--- a/configs/presets/base/plain-text-language.ts
+++ b/configs/presets/base/plain-text-language.ts
@@ -1,0 +1,80 @@
+import { TextSourceCodeBase, VisitNodeStep } from '@eslint/plugin-kit';
+
+type SourcePosition = { readonly line: number; readonly column: number; };
+type SourceLocation = { readonly start: SourcePosition; readonly end: SourcePosition; };
+type ProgramNode = {
+    readonly type: 'Program';
+    readonly body: readonly never[];
+    readonly comments: readonly never[];
+    readonly tokens: readonly never[];
+    readonly range: readonly [number, number];
+    readonly loc: SourceLocation;
+};
+
+type LanguageFile = { readonly body: string; };
+type ParseResult = { readonly ast: ProgramNode; };
+type SuccessfulParseResult = { readonly ok: true; readonly ast: ProgramNode; };
+
+const lineEndingPattern = /\r\n|\n|\r/u;
+
+function buildProgramNode(text: string): ProgramNode {
+    const lines = text.split(lineEndingPattern);
+    const lastLine = lines.at(-1) ?? '';
+    return {
+        type: 'Program',
+        body: [],
+        comments: [],
+        tokens: [],
+        range: [ 0, text.length ],
+        loc: {
+            start: { line: 1, column: 0 },
+            end: { line: lines.length, column: lastLine.length }
+        }
+    };
+}
+
+function* traverseProgram(ast: ProgramNode): IterableIterator<VisitNodeStep> {
+    yield new VisitNodeStep({ target: ast, phase: 1, args: [ ast ] });
+    yield new VisitNodeStep({ target: ast, phase: 2, args: [ ast ] });
+}
+
+function createPlainTextSourceCode(file: LanguageFile, parseResult: ParseResult): TextSourceCodeBase {
+    const sourceCode = new TextSourceCodeBase({ text: file.body, ast: parseResult.ast });
+    Object.assign(sourceCode, {
+        getLoc(node: ProgramNode): SourceLocation {
+            return node.loc;
+        },
+        getRange(node: ProgramNode): readonly [number, number] {
+            return node.range;
+        },
+        traverse(): IterableIterator<VisitNodeStep> {
+            return traverseProgram(parseResult.ast);
+        }
+    });
+    return sourceCode;
+}
+
+function noopValidateLanguageOptions(): void {
+    return undefined;
+}
+
+function parsePlainText(file: LanguageFile): SuccessfulParseResult {
+    return { ok: true, ast: buildProgramNode(file.body) };
+}
+
+const plainTextLanguage = {
+    fileType: 'text',
+    lineStart: 1,
+    columnStart: 0,
+    nodeTypeKey: 'type',
+    visitorKeys: { Program: [] },
+    defaultLanguageOptions: {},
+    validateLanguageOptions: noopValidateLanguageOptions,
+    parse: parsePlainText,
+    createSourceCode: createPlainTextSourceCode
+};
+
+export const plainTextLanguagePlugin = {
+    meta: { name: '@enormora/eslint-config-plain-text-language', version: '1.0.0' },
+    languages: { any: plainTextLanguage }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@ben_12/eslint-plugin-dprint": "1.21.1",
-                "@ben_12/eslint-simple-parser": "0.1.0",
                 "@cspell/eslint-plugin": "10.0.1",
                 "@dprint/json": "0.21.3",
                 "@dprint/markdown": "0.22.1",
@@ -18,6 +17,7 @@
                 "@dprint/typescript": "0.96.1",
                 "@eslint-community/eslint-plugin-eslint-comments": "4.7.2",
                 "@eslint/markdown": "8.0.2",
+                "@eslint/plugin-kit": "0.7.2",
                 "@stylistic/eslint-plugin": "5.10.0",
                 "@typescript-eslint/eslint-plugin": "8.61.0",
                 "@typescript-eslint/parser": "8.61.0",
@@ -442,15 +442,6 @@
                 "dprint-plugin-yaml": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@ben_12/eslint-simple-parser": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@ben_12/eslint-simple-parser/-/eslint-simple-parser-0.1.0.tgz",
-            "integrity": "sha512-7wAJPcr7Xcffr3G+nl+fxpJP2/EK4Q7DjkDSEepE9raax0Qlaa30IJsjhHh93dZz+0SI5OAu2HJNqS0maFNUlg==",
-            "license": "MIT",
-            "peerDependencies": {
-                "eslint": ">=7.0.0"
             }
         },
         "node_modules/@braidai/lang": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     },
     "dependencies": {
         "@ben_12/eslint-plugin-dprint": "1.21.1",
-        "@ben_12/eslint-simple-parser": "0.1.0",
         "@cspell/eslint-plugin": "10.0.1",
         "@dprint/json": "0.21.3",
         "@dprint/markdown": "0.22.1",
@@ -24,6 +23,7 @@
         "@dprint/typescript": "0.96.1",
         "@eslint-community/eslint-plugin-eslint-comments": "4.7.2",
         "@eslint/markdown": "8.0.2",
+        "@eslint/plugin-kit": "0.7.2",
         "@stylistic/eslint-plugin": "5.10.0",
         "@typescript-eslint/eslint-plugin": "8.61.0",
         "@typescript-eslint/parser": "8.61.0",

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -12,6 +12,7 @@ const sharedSourceFiles = [
     'presets/base/cspell-config.js',
     'presets/base/markdown-lint-rules.js',
     'presets/base/package-json.js',
+    'presets/base/plain-text-language.js',
     'rule-sets/best-practices.js',
     'rule-sets/restricted-syntax.js',
     'rule-sets/stylistic.js'


### PR DESCRIPTION
The dprint JSON/YAML/TOML blocks parsed files through `@ben_12/eslint-simple-parser`, an unmaintained 0.1.0 stub that ships no `meta`. ESLint 10's cache serialization rejects parsers without `meta`, so downstream consumers running `eslint --cache` crashed on those blocks.

Replaced the stub parser with a small in-repo flat-config language plugin (`plain-text-language.ts`) built on `@eslint/plugin-kit`'s `TextSourceCodeBase` + `VisitNodeStep`. It produces a single `Program` node so `dprint/json`, `dprint/yaml`, and `dprint/toml` keep firing under `language: 'plain-text/any'`. Language plugins bypass the parser-cache `meta` path, so `--cache` works.

`package.json` still flows through `jsonc-eslint-parser` because `package-json/*` and `json-schema-validator/no-invalid` depend on JSON-specific AST nodes and `parserServices.isJSON`. The JSON dprint/prettier blocks now ignore `**/package.json`, and a dedicated block re-applies `dprint/json` / `prettier/prettier` on top of the jsonc-parsed `package.json` so formatting coverage is preserved.
