### PR TITLE
Add `enormora-typescript/prefer-readonly-types` rule

### DIFF
--- a/configs/plugins/enormora-typescript/enormora-typescript-plugin.ts
+++ b/configs/plugins/enormora-typescript/enormora-typescript-plugin.ts
@@ -1,14 +1,16 @@
 import type { Rule } from 'eslint';
 import { noImpureSatisfiesRule } from './no-impure-satisfies.ts';
 import { preferNamedCallableTypesRule } from './prefer-named-callable-types.ts';
+import { preferReadonlyTypesRule } from './prefer-readonly-types.ts';
 
 type EnormoraTypescriptPlugin = {
-    readonly rules: Record<string, Rule.RuleModule>;
+    readonly rules: Readonly<Record<string, Rule.RuleModule>>;
 };
 
 export const enormoraTypescriptPlugin: EnormoraTypescriptPlugin = {
     rules: {
         'no-impure-satisfies': noImpureSatisfiesRule as unknown as Rule.RuleModule,
-        'prefer-named-callable-types': preferNamedCallableTypesRule as unknown as Rule.RuleModule
+        'prefer-named-callable-types': preferNamedCallableTypesRule as unknown as Rule.RuleModule,
+        'prefer-readonly-types': preferReadonlyTypesRule as unknown as Rule.RuleModule
     }
 };

--- a/configs/plugins/enormora-typescript/prefer-readonly-types.ts
+++ b/configs/plugins/enormora-typescript/prefer-readonly-types.ts
@@ -1,0 +1,328 @@
+import {
+    AST_NODE_TYPES,
+    ESLintUtils,
+    type TSESLint,
+    type TSESTree
+} from '@typescript-eslint/utils';
+
+function ruleUrl(ruleName: string): string {
+    return `https://github.com/enormora/eslint-config/blob/main/configs/plugins/enormora-typescript/${ruleName}.ts`;
+}
+
+const { RuleCreator: ruleCreator } = ESLintUtils;
+const buildRule = ruleCreator(ruleUrl);
+
+const namedReferenceRenames: ReadonlyMap<string, string> = new Map([
+    [ 'Array', 'ReadonlyArray' ],
+    [ 'Map', 'ReadonlyMap' ],
+    [ 'Set', 'ReadonlySet' ]
+]);
+
+const namedReferenceReadonlyForms: ReadonlySet<string> = new Set([
+    'ReadonlyArray',
+    'ReadonlyMap',
+    'ReadonlySet',
+    'Readonly'
+]);
+
+const recordReferenceName = 'Record';
+
+const elementParensRequiredTypes: ReadonlySet<string> = new Set([
+    AST_NODE_TYPES.TSUnionType,
+    AST_NODE_TYPES.TSIntersectionType,
+    AST_NODE_TYPES.TSFunctionType,
+    AST_NODE_TYPES.TSConstructorType,
+    AST_NODE_TYPES.TSConditionalType,
+    AST_NODE_TYPES.TSTypeOperator
+]);
+
+type Fixer = TSESLint.RuleFixer;
+type FixResult = TSESLint.RuleFix;
+type SourceCode = Readonly<TSESLint.SourceCode>;
+
+// `node.parent` is typed as a non-nullable `Node` but the program root carries
+// a runtime `null`. Funnel parent access through this helper so the loop
+// terminates correctly without fighting the type system.
+function readParent(node: TSESTree.Node): TSESTree.Node | undefined {
+    const raw = (node as { readonly parent?: TSESTree.Node | null; }).parent;
+    return raw ?? undefined;
+}
+
+function hasTypeLiteralOrInterfaceBodyAncestor(node: TSESTree.Node): boolean {
+    let current = readParent(node);
+    while (current !== undefined) {
+        if (current.type === AST_NODE_TYPES.TSTypeLiteral) {
+            return true;
+        }
+        if (current.type === AST_NODE_TYPES.TSInterfaceBody) {
+            return true;
+        }
+        current = readParent(current);
+    }
+    return false;
+}
+
+function isMemberOfNestedTypeLiteral(
+    member: TSESTree.TSIndexSignature | TSESTree.TSPropertySignature
+): boolean {
+    const { parent } = member;
+    if (parent.type !== AST_NODE_TYPES.TSTypeLiteral) {
+        return false;
+    }
+    return parent.parent.type !== AST_NODE_TYPES.TSTypeAliasDeclaration;
+}
+
+function isWrappedInReadonlyOperator(node: TSESTree.Node): boolean {
+    const parent = readParent(node);
+    if (parent?.type !== AST_NODE_TYPES.TSTypeOperator) {
+        return false;
+    }
+    return parent.operator === 'readonly';
+}
+
+function elementNeedsParens(element: TSESTree.Node): boolean {
+    return elementParensRequiredTypes.has(element.type);
+}
+
+function resultNeedsOuterParens(node: TSESTree.Node): boolean {
+    const parent = readParent(node);
+    if (parent === undefined) {
+        return false;
+    }
+    return parent.type === AST_NODE_TYPES.TSArrayType || parent.type === AST_NODE_TYPES.TSRestType;
+}
+
+function isMappedTypeReadonly(node: TSESTree.TSMappedType): boolean {
+    return node.readonly === true || node.readonly === '+';
+}
+
+function isWrappedInReadonlyUtility(node: TSESTree.TSTypeReference): boolean {
+    const { parent } = node;
+    if (parent.type !== AST_NODE_TYPES.TSTypeParameterInstantiation) {
+        return false;
+    }
+    const grandparent = parent.parent;
+    if (grandparent.type !== AST_NODE_TYPES.TSTypeReference) {
+        return false;
+    }
+    const { typeName } = grandparent;
+    return typeName.type === AST_NODE_TYPES.Identifier && typeName.name === 'Readonly';
+}
+
+function getNamedReferenceName(node: TSESTree.TSTypeReference): string | undefined {
+    const { typeName } = node;
+    if (typeName.type !== AST_NODE_TYPES.Identifier) {
+        return undefined;
+    }
+    return typeName.name;
+}
+
+function buildArrayReadonlyText(
+    node: TSESTree.TSArrayType,
+    sourceCode: SourceCode
+): string {
+    const elementText = sourceCode.getText(node.elementType);
+    const wrappedElement = elementNeedsParens(node.elementType) ? `(${elementText})` : elementText;
+    const readonlyForm = `readonly ${wrappedElement}[]`;
+    return resultNeedsOuterParens(node) ? `(${readonlyForm})` : readonlyForm;
+}
+
+function buildTupleReadonlyText(
+    node: TSESTree.TSTupleType,
+    sourceCode: SourceCode
+): string {
+    const tupleText = sourceCode.getText(node);
+    const readonlyForm = `readonly ${tupleText}`;
+    return resultNeedsOuterParens(node) ? `(${readonlyForm})` : readonlyForm;
+}
+
+const description = 'Require `readonly` on properties, index signatures, arrays, tuples, mapped types, and the ' +
+    '`Array`/`Map`/`Set`/`Record` references that appear nested inside object type literals or ' +
+    'interface bodies. Mimics the deprecated `functional/prefer-readonly-type` rule but limited ' +
+    'to inline literal contexts so that named references are not recursed into.';
+
+const messages = {
+    arrayShouldBeReadonly: 'Array type should be wrapped in `readonly`.',
+    indexSignatureShouldBeReadonly: 'Index signature should be marked `readonly`.',
+    mappedTypeShouldBeReadonly: 'Mapped type should declare `readonly` for its produced members.',
+    namedReferenceShouldBeReadonly: 'Use `{{readonlyName}}` instead of `{{name}}` inside an inline literal type.',
+    propertyShouldBeReadonly: 'Property `{{name}}` should be marked `readonly`.',
+    recordShouldBeReadonly: 'Wrap `Record<...>` in `Readonly<...>` inside an inline literal type.',
+    tupleShouldBeReadonly: 'Tuple type should be wrapped in `readonly`.'
+};
+
+function describePropertyName(key: TSESTree.PropertyName, sourceCode: SourceCode): string {
+    if (key.type === AST_NODE_TYPES.Identifier) {
+        return key.name;
+    }
+    return sourceCode.getText(key);
+}
+
+type ReportContext = TSESLint.RuleContext<keyof typeof messages, readonly []>;
+
+function reportRenameNamedReference(
+    context: ReportContext,
+    node: TSESTree.TSTypeReference,
+    name: string,
+    readonlyName: string
+): void {
+    context.report({
+        node,
+        messageId: 'namedReferenceShouldBeReadonly',
+        data: { name, readonlyName },
+        fix(fixer: Fixer): FixResult {
+            return fixer.replaceText(node.typeName, readonlyName);
+        }
+    });
+}
+
+function reportRecordReference(
+    context: ReportContext,
+    node: TSESTree.TSTypeReference,
+    sourceCode: SourceCode
+): void {
+    context.report({
+        node,
+        messageId: 'recordShouldBeReadonly',
+        fix(fixer: Fixer): FixResult {
+            return fixer.replaceText(node, `Readonly<${sourceCode.getText(node)}>`);
+        }
+    });
+}
+
+function shouldInspectNamedReference(node: TSESTree.TSTypeReference, name: string): boolean {
+    if (namedReferenceReadonlyForms.has(name)) {
+        return false;
+    }
+    if (!hasTypeLiteralOrInterfaceBodyAncestor(node)) {
+        return false;
+    }
+    return !isWrappedInReadonlyUtility(node);
+}
+
+function reportNamedReferenceIfApplicable(
+    context: ReportContext,
+    sourceCode: SourceCode,
+    node: TSESTree.TSTypeReference
+): void {
+    const name = getNamedReferenceName(node);
+    if (name === undefined || !shouldInspectNamedReference(node, name)) {
+        return;
+    }
+    const readonlyName = namedReferenceRenames.get(name);
+    if (readonlyName !== undefined) {
+        reportRenameNamedReference(context, node, name, readonlyName);
+        return;
+    }
+    if (name === recordReferenceName) {
+        reportRecordReference(context, node, sourceCode);
+    }
+}
+
+export const preferReadonlyTypesRule = buildRule({
+    name: 'prefer-readonly-types',
+    meta: {
+        type: 'problem',
+        fixable: 'code',
+        docs: { description },
+        messages,
+        schema: []
+    },
+    defaultOptions: [],
+    create(context) {
+        const { sourceCode } = context;
+
+        return {
+            TSPropertySignature(node: TSESTree.TSPropertySignature) {
+                if (node.readonly) {
+                    return;
+                }
+                if (!isMemberOfNestedTypeLiteral(node)) {
+                    return;
+                }
+                context.report({
+                    node,
+                    messageId: 'propertyShouldBeReadonly',
+                    data: { name: describePropertyName(node.key, sourceCode) },
+                    fix(fixer: Fixer): FixResult {
+                        return fixer.insertTextBefore(node, 'readonly ');
+                    }
+                });
+            },
+
+            TSIndexSignature(node: TSESTree.TSIndexSignature) {
+                if (node.readonly) {
+                    return;
+                }
+                if (!isMemberOfNestedTypeLiteral(node)) {
+                    return;
+                }
+                context.report({
+                    node,
+                    messageId: 'indexSignatureShouldBeReadonly',
+                    fix(fixer: Fixer): FixResult {
+                        return fixer.insertTextBefore(node, 'readonly ');
+                    }
+                });
+            },
+
+            TSArrayType(node: TSESTree.TSArrayType) {
+                if (isWrappedInReadonlyOperator(node)) {
+                    return;
+                }
+                if (!hasTypeLiteralOrInterfaceBodyAncestor(node)) {
+                    return;
+                }
+                context.report({
+                    node,
+                    messageId: 'arrayShouldBeReadonly',
+                    fix(fixer: Fixer): FixResult {
+                        return fixer.replaceText(node, buildArrayReadonlyText(node, sourceCode));
+                    }
+                });
+            },
+
+            TSTupleType(node: TSESTree.TSTupleType) {
+                if (isWrappedInReadonlyOperator(node)) {
+                    return;
+                }
+                if (!hasTypeLiteralOrInterfaceBodyAncestor(node)) {
+                    return;
+                }
+                context.report({
+                    node,
+                    messageId: 'tupleShouldBeReadonly',
+                    fix(fixer: Fixer): FixResult {
+                        return fixer.replaceText(node, buildTupleReadonlyText(node, sourceCode));
+                    }
+                });
+            },
+
+            TSMappedType(node: TSESTree.TSMappedType) {
+                if (isMappedTypeReadonly(node)) {
+                    return;
+                }
+                if (!hasTypeLiteralOrInterfaceBodyAncestor(node)) {
+                    return;
+                }
+                const openBracketToken = sourceCode.getFirstToken(node, function isOpenBracket(token) {
+                    return token.value === '[';
+                });
+                if (openBracketToken === null) {
+                    return;
+                }
+                context.report({
+                    node,
+                    messageId: 'mappedTypeShouldBeReadonly',
+                    fix(fixer: Fixer): FixResult {
+                        return fixer.insertTextBefore(openBracketToken, 'readonly ');
+                    }
+                });
+            },
+
+            TSTypeReference(node: TSESTree.TSTypeReference) {
+                reportNamedReferenceIfApplicable(context, sourceCode, node);
+            }
+        };
+    }
+});

--- a/configs/presets/typescript/typescript.ts
+++ b/configs/presets/typescript/typescript.ts
@@ -202,6 +202,7 @@ export const typescriptConfig = {
         '@typescript-eslint/no-unnecessary-type-assertion': 'error',
         'enormora-typescript/no-impure-satisfies': 'error',
         'enormora-typescript/prefer-named-callable-types': 'error',
+        'enormora-typescript/prefer-readonly-types': 'error',
         '@typescript-eslint/no-unused-private-class-members': 'error',
         ...configureWrappedCoreRule('no-unused-vars', undefined),
         ...configureWrappedCoreRule('no-useless-constructor', undefined),

--- a/configs/rule-sets/restricted-syntax.ts
+++ b/configs/rule-sets/restricted-syntax.ts
@@ -7,7 +7,7 @@ type RestrictedSyntaxRestriction = {
 };
 
 type RestrictedSyntaxPlugin = {
-    readonly rules: Record<string, Rule.RuleModule | undefined>;
+    readonly rules: Readonly<Record<string, Rule.RuleModule | undefined>>;
 };
 
 type NoClassDeclarationOptions = {

--- a/test/cspell-helper.test.ts
+++ b/test/cspell-helper.test.ts
@@ -26,7 +26,10 @@ suite('withCspellWords helper', function () {
 
     test('appends the provided words to the base cspell.words list', function () {
         const block = withCspellWords([ 'enormora', 'packtory' ]);
-        const [ , options ] = block.rules['@cspell/spellchecker'] as [string, { cspell: { words: string[]; }; }];
+        const [ , options ] = block.rules['@cspell/spellchecker'] as [
+            string,
+            { readonly cspell: { readonly words: readonly string[]; }; }
+        ];
         assert.deepStrictEqual(options.cspell.words, [ 'enormora', 'packtory' ]);
     });
 

--- a/test/integration/base-typescript-node.test.ts
+++ b/test/integration/base-typescript-node.test.ts
@@ -51,6 +51,7 @@ const expectedViolationRuleIds = [
     'complexity',
     'default-case',
     'dprint/typescript',
+    'enormora-typescript/prefer-readonly-types',
     'eqeqeq',
     'functional/no-this-expressions',
     'functional/prefer-immutable-types',

--- a/test/integration/base-typescript-react-tsx.test.ts
+++ b/test/integration/base-typescript-react-tsx.test.ts
@@ -24,6 +24,7 @@ const expectedViolationRuleIds = [
     'arrow-body-style',
     'destructuring/in-params',
     'dprint/typescript',
+    'enormora-typescript/prefer-readonly-types',
     'functional/prefer-immutable-types',
     'functional/type-declaration-immutability',
     'react-hooks/exhaustive-deps',

--- a/test/integration/base-typescript.test.ts
+++ b/test/integration/base-typescript.test.ts
@@ -53,6 +53,7 @@ const expectedViolationRuleIds = [
     'complexity',
     'default-case',
     'dprint/typescript',
+    'enormora-typescript/prefer-readonly-types',
     'eqeqeq',
     'functional/no-this-expressions',
     'functional/prefer-immutable-types',

--- a/test/rules/prefer-readonly-types.test.ts
+++ b/test/rules/prefer-readonly-types.test.ts
@@ -1,0 +1,210 @@
+import assert from 'node:assert';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { Linter } from 'eslint';
+import typescriptParser from '@typescript-eslint/parser';
+import { suite, suiteTeardown, test } from 'mocha';
+import {
+    enormoraTypescriptPlugin
+} from '../../configs/plugins/enormora-typescript/enormora-typescript-plugin.ts';
+import {
+    preferReadonlyTypesRule
+} from '../../configs/plugins/enormora-typescript/prefer-readonly-types.ts';
+
+RuleTester.afterAll = suiteTeardown;
+RuleTester.describe = function registerSuite(name: string, fn: () => void): void {
+    suite(name, fn);
+};
+RuleTester.it = function registerTest(name: string, fn: () => void): void {
+    test(name, fn);
+};
+RuleTester.itOnly = function registerTestOnly(name: string, fn: () => void): void {
+    test(name, fn);
+};
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            projectService: {
+                allowDefaultProject: [ '*.ts*' ]
+            },
+            tsconfigRootDir: process.cwd()
+        }
+    }
+});
+
+const propertySignatureType = AST_NODE_TYPES.TSPropertySignature;
+const indexSignatureType = AST_NODE_TYPES.TSIndexSignature;
+const arrayType = AST_NODE_TYPES.TSArrayType;
+const tupleType = AST_NODE_TYPES.TSTupleType;
+const mappedType = AST_NODE_TYPES.TSMappedType;
+const typeReferenceType = AST_NODE_TYPES.TSTypeReference;
+
+ruleTester.run('prefer-readonly-types', preferReadonlyTypesRule, {
+    valid: [
+        // Surface-level property in a top-level type alias is handled by the existing
+        // functional/* rules — our rule deliberately skips it to avoid double-reporting.
+        { code: 'type Surface = { foo: string };' },
+        // Surface-level property in an interface body — same reason.
+        { code: 'interface Surface { foo: string }' },
+        // Top-level array — no enclosing literal, our rule skips.
+        { code: 'type Surface = string[];' },
+        // Function parameter array — no enclosing literal, our rule skips.
+        { code: 'declare function takeArr(items: string[]): void;' },
+        // Variable annotation array — no enclosing literal.
+        { code: 'declare const items: string[];' },
+        // Nested property already readonly.
+        { code: 'type Nested = { readonly outer: { readonly inner: string } };' },
+        // Nested array already wrapped in readonly.
+        { code: 'type Nested = { readonly outer: readonly string[] };' },
+        // Nested tuple already wrapped.
+        { code: 'type Nested = { readonly outer: readonly [string, number] };' },
+        // Nested mapped type already readonly.
+        { code: 'type Nested = { readonly outer: { readonly [K in string]: number } };' },
+        // Nested ReadonlyArray reference.
+        { code: 'type Nested = { readonly outer: ReadonlyArray<string> };' },
+        // Nested ReadonlyMap / ReadonlySet references.
+        { code: 'type Nested = { readonly outer: ReadonlyMap<string, number> };' },
+        { code: 'type Nested = { readonly outer: ReadonlySet<string> };' },
+        // Record wrapped in Readonly already.
+        { code: 'type Nested = { readonly outer: Readonly<Record<string, number>> };' },
+        // Named class reference nested inside literal — not recursed into.
+        {
+            code: [
+                'declare class Existing { id: number }',
+                'type Wrapper = { readonly outer: Existing };'
+            ]
+                .join('\n')
+        },
+        // Index signature already readonly on a nested literal.
+        { code: 'type Nested = { readonly outer: { readonly [key: string]: number } };' }
+    ],
+    invalid: [
+        // Nested property missing readonly.
+        {
+            code: 'type Nested = { readonly outer: { foo: string } };',
+            output: 'type Nested = { readonly outer: { readonly foo: string } };',
+            errors: [ { messageId: 'propertyShouldBeReadonly', type: propertySignatureType } ]
+        },
+        // Nested property inside an interface body's literal value.
+        {
+            code: 'interface Wrapper { readonly outer: { foo: string } }',
+            output: 'interface Wrapper { readonly outer: { readonly foo: string } }',
+            errors: [ { messageId: 'propertyShouldBeReadonly', type: propertySignatureType } ]
+        },
+        // Nested index signature missing readonly.
+        {
+            code: 'type Nested = { readonly outer: { [key: string]: number } };',
+            output: 'type Nested = { readonly outer: { readonly [key: string]: number } };',
+            errors: [ { messageId: 'indexSignatureShouldBeReadonly', type: indexSignatureType } ]
+        },
+        // Nested array missing readonly.
+        {
+            code: 'type Nested = { readonly outer: string[] };',
+            output: 'type Nested = { readonly outer: readonly string[] };',
+            errors: [ { messageId: 'arrayShouldBeReadonly', type: arrayType } ]
+        },
+        // Union element wrapped in parens before readonly.
+        {
+            code: 'type Nested = { readonly outer: (string | number)[] };',
+            output: 'type Nested = { readonly outer: readonly (string | number)[] };',
+            errors: [ { messageId: 'arrayShouldBeReadonly', type: arrayType } ]
+        },
+        // Nested tuple missing readonly.
+        {
+            code: 'type Nested = { readonly outer: [string, number] };',
+            output: 'type Nested = { readonly outer: readonly [string, number] };',
+            errors: [ { messageId: 'tupleShouldBeReadonly', type: tupleType } ]
+        },
+        // Tuple with rest array — autofix needs two passes: outer tuple first, then
+        // inner array wraps with parens.
+        {
+            code: 'type Nested = { readonly outer: [string, ...string[]] };',
+            output: [
+                'type Nested = { readonly outer: readonly [string, ...string[]] };',
+                'type Nested = { readonly outer: readonly [string, ...(readonly string[])] };'
+            ],
+            errors: [
+                { messageId: 'tupleShouldBeReadonly', type: tupleType },
+                { messageId: 'arrayShouldBeReadonly', type: arrayType }
+            ]
+        },
+        // Nested mapped type missing readonly modifier.
+        {
+            code: 'type Nested = { readonly outer: { [K in string]: number } };',
+            output: 'type Nested = { readonly outer: { readonly [K in string]: number } };',
+            errors: [ { messageId: 'mappedTypeShouldBeReadonly', type: mappedType } ]
+        },
+        // Nested Array<T> reference renamed.
+        {
+            code: 'type Nested = { readonly outer: Array<string> };',
+            output: 'type Nested = { readonly outer: ReadonlyArray<string> };',
+            errors: [
+                {
+                    messageId: 'namedReferenceShouldBeReadonly',
+                    type: typeReferenceType,
+                    data: { name: 'Array', readonlyName: 'ReadonlyArray' }
+                }
+            ]
+        },
+        // Nested Map<K, V> reference renamed.
+        {
+            code: 'type Nested = { readonly outer: Map<string, number> };',
+            output: 'type Nested = { readonly outer: ReadonlyMap<string, number> };',
+            errors: [
+                {
+                    messageId: 'namedReferenceShouldBeReadonly',
+                    type: typeReferenceType,
+                    data: { name: 'Map', readonlyName: 'ReadonlyMap' }
+                }
+            ]
+        },
+        // Nested Set<T> reference renamed.
+        {
+            code: 'type Nested = { readonly outer: Set<string> };',
+            output: 'type Nested = { readonly outer: ReadonlySet<string> };',
+            errors: [
+                {
+                    messageId: 'namedReferenceShouldBeReadonly',
+                    type: typeReferenceType,
+                    data: { name: 'Set', readonlyName: 'ReadonlySet' }
+                }
+            ]
+        },
+        // Nested Record<K, V> wrapped in Readonly<>.
+        {
+            code: 'type Nested = { readonly outer: Record<string, number> };',
+            output: 'type Nested = { readonly outer: Readonly<Record<string, number>> };',
+            errors: [ { messageId: 'recordShouldBeReadonly', type: typeReferenceType } ]
+        }
+    ]
+});
+
+// RuleTester only applies one autofix pass per case. For nested arrays/tuples
+// the final shape requires multiple passes, so `verifyAndFix` is used here to
+// confirm the rule converges to the expected output.
+suite('prefer-readonly-types autofix convergence', function () {
+    const linter = new Linter({ configType: 'flat' });
+    const configs = [
+        {
+            files: [ '**/*.ts' ],
+            plugins: { 'enormora-typescript': enormoraTypescriptPlugin },
+            languageOptions: { parser: typescriptParser },
+            rules: { 'enormora-typescript/prefer-readonly-types': 'error' }
+        }
+    ] as unknown as Linter.Config[];
+
+    test('nested array-of-array converges to fully readonly nesting', function () {
+        const input = 'type Nested = { readonly outer: string[][] };';
+        const expected = 'type Nested = { readonly outer: readonly (readonly string[])[] };';
+        const result = linter.verifyAndFix(input, configs, { filename: 'probe.ts' });
+        assert.strictEqual(result.output, expected);
+    });
+
+    test('tuple with rest of mutable array converges to nested readonly', function () {
+        const input = 'type Nested = { readonly outer: [string, ...string[]] };';
+        const expected = 'type Nested = { readonly outer: readonly [string, ...(readonly string[])] };';
+        const result = linter.verifyAndFix(input, configs, { filename: 'probe.ts' });
+        assert.strictEqual(result.output, expected);
+    });
+});


### PR DESCRIPTION
Adds a custom `enormora-typescript/prefer-readonly-types` rule that enforces `readonly` on nested members of inline type literals: object property signatures, index signatures, arrays, tuples, mapped types, and `Array` / `Map` / `Set` / `Record` references. Named class or interface references are intentionally not recursed into, mirroring the deprecated `functional/prefer-readonly-type` rule.

The existing `functional/prefer-immutable-types` and `functional/type-declaration-immutability` rules continue to cover the surface level; this rule fills the deep-literal gap they leave by design. Autofix wraps elements in parentheses where a bare `readonly` keyword would otherwise re-bind incorrectly, so `string[][]` converges to `readonly (readonly string[])[]` and `[string, ...string[]]` to `readonly [string, ...(readonly string[])]` over consecutive autofix passes.
