### PR TITLE
Add `testSupportConfig` for test-related non-test files

### DIFF
--- a/configs/presets/ava/ava.md
+++ b/configs/presets/ava/ava.md
@@ -29,3 +29,22 @@ export default [
     }
 ];
 ```
+
+## `testSupportConfig`
+
+This package also re-exports `testSupportConfig` for test-related files that are not themselves test files (helpers, mocks, fixtures, setup). It applies the same shared relaxations as `avaConfig` without enabling any `ava/*` rules.
+
+```javascript
+import { avaConfig, testSupportConfig } from '@enormora/eslint-config-ava';
+
+export default [
+    {
+        ...avaConfig,
+        files: [ '**/*.test.js' ]
+    },
+    {
+        ...testSupportConfig,
+        files: [ '**/test/helpers/**', '**/test/fixtures/**', '**/test/mocks/**' ]
+    }
+];
+```

--- a/configs/presets/ava/ava.ts
+++ b/configs/presets/ava/ava.ts
@@ -1,6 +1,10 @@
 import avaPlugin from 'eslint-plugin-ava';
 import { testRuleSet } from '../test-base/test-base.ts';
 
+/* eslint-disable no-barrel-files/no-barrel-files -- expose testSupportConfig as public API so consumers can apply the shared relaxations to non-test test files without depending on @enormora/eslint-config-test-base directly */
+export { testSupportConfig } from '../test-base/test-base.ts';
+/* eslint-enable no-barrel-files/no-barrel-files -- end of public re-exports */
+
 export const avaConfig = {
     plugins: {
         ava: avaPlugin

--- a/configs/presets/mocha/mocha.md
+++ b/configs/presets/mocha/mocha.md
@@ -29,3 +29,22 @@ export default [
     }
 ];
 ```
+
+## `testSupportConfig`
+
+This package also re-exports `testSupportConfig` for test-related files that are not themselves test files (helpers, mocks, fixtures, setup). It applies the same shared relaxations as `mochaConfig` without enabling any `mocha/*` rules.
+
+```javascript
+import { mochaConfig, testSupportConfig } from '@enormora/eslint-config-mocha';
+
+export default [
+    {
+        ...mochaConfig,
+        files: [ '**/*.test.js' ]
+    },
+    {
+        ...testSupportConfig,
+        files: [ '**/test/helpers/**', '**/test/fixtures/**', '**/test/mocks/**' ]
+    }
+];
+```

--- a/configs/presets/mocha/mocha.ts
+++ b/configs/presets/mocha/mocha.ts
@@ -2,6 +2,10 @@ import type { Linter } from 'eslint';
 import mochaPlugin from 'eslint-plugin-mocha';
 import { testRuleSet } from '../test-base/test-base.ts';
 
+/* eslint-disable no-barrel-files/no-barrel-files -- expose testSupportConfig as public API so consumers can apply the shared relaxations to non-test test files without depending on @enormora/eslint-config-test-base directly */
+export { testSupportConfig } from '../test-base/test-base.ts';
+/* eslint-enable no-barrel-files/no-barrel-files -- end of public re-exports */
+
 export const mochaConfig = {
     plugins: {
         mocha: mochaPlugin

--- a/configs/presets/test-base/test-base.md
+++ b/configs/presets/test-base/test-base.md
@@ -2,6 +2,23 @@
 
 [![npm](https://img.shields.io/npm/v/@enormora/eslint-config-test-base?label=)](https://www.npmjs.com/package/@enormora/eslint-config-test-base)
 
-Shared rule set used by the test-framework presets (`@enormora/eslint-config-ava`, `@enormora/eslint-config-mocha`, `@enormora/eslint-config-vitest`). It tweaks a few rules from the base preset to be more lenient inside test files.
+Shared relaxations for test code. The framework presets (`@enormora/eslint-config-ava`, `@enormora/eslint-config-mocha`, `@enormora/eslint-config-vitest`) consume this package transitively and apply these relaxations on top of their framework-specific rules.
 
-This package is consumed transitively through one of the test-framework presets and is not intended to be used directly.
+This package also exposes `testSupportConfig` for direct use on test-related files that are not themselves test files, e.g. test helpers, mocks, fixtures, or setup files. It applies the same relaxations as the framework presets without enabling any framework-specific rules.
+
+## Usage
+
+```javascript
+import { baseConfig } from '@enormora/eslint-config-base';
+import { testSupportConfig } from '@enormora/eslint-config-test-base';
+
+export default [
+    ...baseConfig,
+    {
+        ...testSupportConfig,
+        files: [ '**/test/helpers/**', '**/test/fixtures/**', '**/test/mocks/**' ]
+    }
+];
+```
+
+The same `testSupportConfig` is re-exported from each framework preset, so projects that already depend on `@enormora/eslint-config-mocha`, `@enormora/eslint-config-ava`, or `@enormora/eslint-config-vitest` can import it from there without adding a direct dependency on this package.

--- a/configs/presets/test-base/test-base.ts
+++ b/configs/presets/test-base/test-base.ts
@@ -1,3 +1,4 @@
+import type { Linter } from 'eslint';
 import { stylisticRuleSet } from '../../rule-sets/stylistic.ts';
 
 const stylisticMaxLenOptions = stylisticRuleSet.rules['@stylistic/max-len'][1] as Record<string, unknown>;
@@ -16,3 +17,7 @@ export const testRuleSet = {
         '@typescript-eslint/no-magic-numbers': 'off'
     }
 };
+
+export const testSupportConfig = {
+    rules: { ...testRuleSet.rules }
+} as unknown as Linter.Config;

--- a/configs/presets/vitest/vitest.md
+++ b/configs/presets/vitest/vitest.md
@@ -29,3 +29,22 @@ export default [
     }
 ];
 ```
+
+## `testSupportConfig`
+
+This package also re-exports `testSupportConfig` for test-related files that are not themselves test files (helpers, mocks, fixtures, setup). It applies the same shared relaxations as `vitestConfig` without enabling any `@vitest/*` rules or Vitest globals.
+
+```javascript
+import { testSupportConfig, vitestConfig } from '@enormora/eslint-config-vitest';
+
+export default [
+    {
+        ...vitestConfig,
+        files: [ '**/*.test.js' ]
+    },
+    {
+        ...testSupportConfig,
+        files: [ '**/test/helpers/**', '**/test/fixtures/**', '**/test/mocks/**' ]
+    }
+];
+```

--- a/configs/presets/vitest/vitest.ts
+++ b/configs/presets/vitest/vitest.ts
@@ -1,6 +1,10 @@
 import vitestPlugin from '@vitest/eslint-plugin';
 import { testRuleSet } from '../test-base/test-base.ts';
 
+/* eslint-disable no-barrel-files/no-barrel-files -- expose testSupportConfig as public API so consumers can apply the shared relaxations to non-test test files without depending on @enormora/eslint-config-test-base directly */
+export { testSupportConfig } from '../test-base/test-base.ts';
+/* eslint-enable no-barrel-files/no-barrel-files -- end of public re-exports */
+
 export const vitestConfig = {
     plugins: {
         vitest: vitestPlugin,

--- a/test/ava.test.ts
+++ b/test/ava.test.ts
@@ -1,6 +1,8 @@
+import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import avaPlugin from 'eslint-plugin-ava';
-import { avaConfig } from '../configs/presets/ava/ava.ts';
+import { avaConfig, testSupportConfig as avaTestSupportConfig } from '../configs/presets/ava/ava.ts';
+import { testSupportConfig } from '../configs/presets/test-base/test-base.ts';
 import {
     checkAllPluginRulesConfigured,
     checkAllTestRulesConfigured,
@@ -33,5 +35,9 @@ suite('ava preset', function () {
 
     test('ava preset config has no validation errors', function () {
         checkConfigToHaveNoValidationIssues(avaConfig);
+    });
+
+    test('re-exports the canonical testSupportConfig', function () {
+        assert.strictEqual(avaTestSupportConfig, testSupportConfig);
     });
 });

--- a/test/mocha.test.ts
+++ b/test/mocha.test.ts
@@ -1,6 +1,8 @@
+import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import mochaPlugin from 'eslint-plugin-mocha';
-import { mochaConfig } from '../configs/presets/mocha/mocha.ts';
+import { mochaConfig, testSupportConfig as mochaTestSupportConfig } from '../configs/presets/mocha/mocha.ts';
+import { testSupportConfig } from '../configs/presets/test-base/test-base.ts';
 import {
     checkAdditionalRulesConfigured,
     checkAllPluginRulesConfigured,
@@ -50,5 +52,9 @@ suite('mocha preset', function () {
                 'prefer-arrow-callback': 'off'
             }
         });
+    });
+
+    test('re-exports the canonical testSupportConfig', function () {
+        assert.strictEqual(mochaTestSupportConfig, testSupportConfig);
     });
 });

--- a/test/test-support.test.ts
+++ b/test/test-support.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { testRuleSet, testSupportConfig } from '../configs/presets/test-base/test-base.ts';
+import { checkConfigToHaveNoValidationIssues } from './rules-configuration.ts';
+
+suite('testSupportConfig', function () {
+    test('exposes exactly the rules from testRuleSet', function () {
+        assert.deepStrictEqual(Object.keys(testSupportConfig.rules ?? {}), Object.keys(testRuleSet.rules));
+    });
+
+    test('has no rules outside testRuleSet', function () {
+        const supportRuleNames = Object.keys(testSupportConfig.rules ?? {});
+        const testRuleNames = Object.keys(testRuleSet.rules);
+        const extraneous = supportRuleNames.filter(function isUnexpected(ruleName) {
+            return !testRuleNames.includes(ruleName);
+        });
+
+        assert.deepStrictEqual(extraneous, []);
+    });
+
+    test('config has no validation errors', function () {
+        checkConfigToHaveNoValidationIssues(testSupportConfig);
+    });
+});

--- a/test/vitest.test.ts
+++ b/test/vitest.test.ts
@@ -1,6 +1,8 @@
+import assert from 'node:assert';
 import vitestPlugin from '@vitest/eslint-plugin';
 import { suite, test } from 'mocha';
-import { vitestConfig } from '../configs/presets/vitest/vitest.ts';
+import { testSupportConfig as vitestTestSupportConfig, vitestConfig } from '../configs/presets/vitest/vitest.ts';
+import { testSupportConfig } from '../configs/presets/test-base/test-base.ts';
 import {
     checkAllPluginRulesConfigured,
     checkAllTestRulesConfigured,
@@ -33,5 +35,9 @@ suite('vitest preset', function () {
 
     test('vitest preset config has no validation errors', function () {
         checkConfigToHaveNoValidationIssues(vitestConfig);
+    });
+
+    test('re-exports the canonical testSupportConfig', function () {
+        assert.strictEqual(vitestTestSupportConfig, testSupportConfig);
     });
 });


### PR DESCRIPTION
Introduces `testSupportConfig` in `@enormora/eslint-config-test-base` and re-exports it from `@enormora/eslint-config-ava`, `@enormora/eslint-config-mocha`, and `@enormora/eslint-config-vitest`.

`testSupportConfig` applies the shared test-file relaxations (max-len `ignoreStrings`, `@typescript-eslint/no-unsafe-type-assertion: off`, magic-numbers off) without enabling any framework-specific rules. The target is files that support tests but are not themselves test files, e.g. test helpers, mocks, fixtures, and setup, where treating them as Mocha/Ava/Vitest test files would produce false positives.

The framework-side re-exports use the existing `no-barrel-files/no-barrel-files` disable convention already used in `base.ts` and `base-with-prettier.ts` to expose public configs from a non-barrel module.
