### PR TITLE
Fix `eslint-plugin` preset plugin import

### DIFF
--- a/configs/presets/eslint-plugin/eslint-plugin.ts
+++ b/configs/presets/eslint-plugin/eslint-plugin.ts
@@ -1,5 +1,5 @@
 import type { Linter } from 'eslint';
-import * as eslintPluginPlugin from 'eslint-plugin-eslint-plugin';
+import eslintPluginPlugin from 'eslint-plugin-eslint-plugin';
 
 type EslintPluginConfigOptions = {
     readonly docsUrlPattern: string;

--- a/test/integration/eslint-plugin.test.ts
+++ b/test/integration/eslint-plugin.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+import { Linter } from 'eslint';
+import { suite, test } from 'mocha';
+import { createEslintPluginConfig } from '../../configs/presets/eslint-plugin/eslint-plugin.ts';
+
+const eslintPluginConfig = createEslintPluginConfig({
+    docsUrlPattern: 'https://example.com/rules/{{name}}.md',
+    descriptionPattern: '^(Enforce|Require|Disallow)'
+});
+
+suite('eslint-plugin integration', function () {
+    test('eslint-plugin preset resolves configured rules through ESLint', function () {
+        const linter = new Linter({ configType: 'flat' });
+        const reports = linter.verify('foo();', [ {
+            ...eslintPluginConfig,
+            rules: { 'eslint-plugin/consistent-output': 'error' }
+        } ], 'foo.js');
+
+        assert.deepStrictEqual(reports, []);
+    });
+});


### PR DESCRIPTION
The `eslint-plugin` preset now registers the actual `eslint-plugin-eslint-plugin` default export so ESLint can resolve configured `eslint-plugin/*` rules. The integration suite covers consuming the returned flat config through ESLint.