### PR TITLE
Require `.ts`, `.mts`, and `.cts` extensions for relative imports

### DIFF
--- a/configs/presets/typescript/typescript.ts
+++ b/configs/presets/typescript/typescript.ts
@@ -478,14 +478,15 @@ export const typescriptConfig = {
 
         'import/extensions': [
             'error',
+            'ignorePackages',
             {
-                ts: 'ignorePackages',
-                mts: 'ignorePackages',
-                cts: 'ignorePackages',
                 js: 'never',
                 mjs: 'never',
                 cjs: 'never',
-                json: 'ignorePackages'
+                json: 'always',
+                ts: 'always',
+                mts: 'always',
+                cts: 'always'
             }
         ],
 

--- a/test/fixtures/base-typescript/package-imports.ts
+++ b/test/fixtures/base-typescript/package-imports.ts
@@ -1,0 +1,5 @@
+import globals from 'globals';
+
+export function countBrowserGlobals(): number {
+    return Object.keys(globals.browser).length;
+}

--- a/test/fixtures/base-typescript/violations.ts
+++ b/test/fixtures/base-typescript/violations.ts
@@ -5,11 +5,12 @@
 import { writeFileSync } from 'fs';
 import fsDefault from 'fs';
 import { writeFileSync as writeAgain } from 'fs';
+import { greet } from './clean.js';
 
 var declaredWithVar = 1;
 var laterAssigned;
 laterAssigned = 2;
-console.log(declaredWithVar, laterAssigned, writeFileSync, fsDefault, writeAgain);
+console.log(declaredWithVar, laterAssigned, writeFileSync, fsDefault, writeAgain, greet);
 
 const concatenated = 'hello' + ' ' + 'world';
 const big = 10000000;

--- a/test/integration/base-typescript.test.ts
+++ b/test/integration/base-typescript.test.ts
@@ -58,6 +58,7 @@ const expectedViolationRuleIds = [
     'functional/prefer-immutable-types',
     'functional/type-declaration-immutability',
     'id-length',
+    'import/extensions',
     'import/no-duplicates',
     'init-declarations',
     'max-depth',
@@ -127,6 +128,18 @@ suite('base+typescript integration', function () {
             return { ruleId: message.ruleId, line: message.line, message: message.message };
         });
         assert.deepStrictEqual(detail, []);
+    });
+
+    test('base+typescript package imports do not require TypeScript extensions', async function () {
+        const { messages } = await lintFixture(configs, comboName, 'package-imports.ts');
+        const extensionMessages = messages
+            .filter(function isImportExtensionMessage(message) {
+                return message.ruleId === 'import/extensions';
+            })
+            .map(function toRuleLocation(message) {
+                return { ruleId: message.ruleId, line: message.line, message: message.message };
+            });
+        assert.deepStrictEqual(extensionMessages, []);
     });
 
     test('base+typescript autofix is idempotent on the violations fixture', async function () {


### PR DESCRIPTION
The TypeScript preset now configures `import/extensions` to ignore package imports by default while requiring TypeScript file extensions on resolved relative imports.

Regression coverage checks that a relative `./clean.js` specifier is reported and that package imports such as `globals` do not require TypeScript extensions.